### PR TITLE
Rename and move binding defintion to interface.

### DIFF
--- a/binding/tfjs_binding.cc
+++ b/binding/tfjs_binding.cc
@@ -184,7 +184,7 @@ static napi_value InitTFNodeJSBinding(napi_env env, napi_value exports) {
   napi_property_descriptor tensor_handle_properties[] = {
       {"bindBuffer", nullptr, SetTensorHandleBuffer, nullptr, nullptr, nullptr,
        napi_default, nullptr},
-      {"data", nullptr, GetTensorHandleData, nullptr, nullptr, nullptr,
+      {"dataSync", nullptr, GetTensorHandleData, nullptr, nullptr, nullptr,
        napi_default, nullptr},
       {"shape", nullptr, nullptr, GetTensorHandleShape, nullptr, nullptr,
        napi_default, nullptr},

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,11 +20,12 @@ import {NodeJSKernelBackend} from './nodejs_kernel_backend';
 
 // tslint:disable-next-line:no-require-imports
 import bindings = require('bindings');
+import {TFJSBinding} from './tfjs_binding';
 
 export function bindTensorFlowBackend() {
   // TODO(kreeger): This anonymous function should throw an exception if the
   // binding is not installed.
-  const nodeBinding = bindings('tfjs_binding.node');
+  const nodeBinding = bindings('tfjs_binding.node') as TFJSBinding;
 
   // TODO(kreeger): Drop the 'webgl' hack when deeplearn 0.5.1 is released to
   // allow proper registration of new backends.

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -20,7 +20,7 @@ import {BackendTimingInfo, KernelBackend} from 'deeplearn/dist/kernels/backend';
 import {DataId, Scalar, Tensor, Tensor1D, Tensor2D, Tensor3D, Tensor4D} from 'deeplearn/dist/tensor';
 import {DataType, Rank} from 'deeplearn/dist/types';
 
-import {Context, TensorHandle} from './tfnodejs';
+import {Context, TensorHandle, TFJSBinding} from './tfjs_binding';
 
 export class NodeJSKernelBackend implements KernelBackend {
   // TODO(kreeger): Drop when 0.5.1 deeplearn is released.
@@ -58,13 +58,9 @@ export class NodeJSKernelBackend implements KernelBackend {
   private handleMap = new WeakMap<DataId, TensorHandle>();
   private context: Context;
 
-  // TODO(kreeger): Find a way to type-def the binding instead of making
-  // everything global.
-  // tslint:disable-next-line:no-any
-  private binding: any;
+  private binding: TFJSBinding;
 
-  // tslint:disable-next-line:no-any
-  constructor(binding: any) {
+  constructor(binding: TFJSBinding) {
     this.binding = binding;
     this.context = new this.binding.Context();
   }
@@ -500,10 +496,10 @@ export class NodeJSKernelBackend implements KernelBackend {
     throw new Error('Method not implemented.');
   }
   async read(dataId: object): Promise<Float32Array|Int32Array|Uint8Array> {
-    return this.handleMap.get(dataId).data();
+    return this.handleMap.get(dataId).dataSync();
   }
   readSync(dataId: object): Float32Array|Int32Array|Uint8Array {
-    return this.handleMap.get(dataId).data();
+    return this.handleMap.get(dataId).dataSync();
   }
   disposeData(dataId: object): void {
     // throw new Error('Method not implemented.');

--- a/src/tfjs_binding.d.ts
+++ b/src/tfjs_binding.d.ts
@@ -21,37 +21,42 @@ declare class TensorHandle {
   constructor();
   constructor(shape: number[], dtype: number);
   bindBuffer(buffer: Float32Array|Int32Array|Uint8Array): void;
-  data(): Float32Array|Int32Array|Uint8Array;
+  dataSync(): Float32Array|Int32Array|Uint8Array;
 
   shape: number[];
   dtype: number;
 }
 
-// TFE Op Attr class.
 declare class TFEOpAttr {
   name: string;
   type: number;
   value: number|boolean|object;
 }
 
-// TF Types
-export const TF_FLOAT: number;
-export const TF_INT32: number;
-export const TF_BOOL: number;
+export interface TFJSBinding {
+  Context: typeof Context;
+  TensorHandle: typeof TensorHandle;
+  TFEOpAttr: typeof TFEOpAttr;
 
-// TF OpAttrTypes
-export const TF_ATTR_STRING: number;
-export const TF_ATTR_INT: number;
-export const TF_ATTR_FLOAT: number;
-export const TF_ATTR_BOOL: number;
-export const TF_ATTR_TYPE: number;
-export const TF_ATTR_SHAPE: number;
-export const TF_ATTR_TENSOR: number;
-export const TF_ATTR_PLACEHOLDER: number;
-export const TF_ATTR_FUNC: number;
+  // TF Types
+  TF_FLOAT: number;
+  TF_INT32: number;
+  TF_BOOL: number;
 
-export const TF_Version: string;
+  // TF OpAttrTypes
+  TF_ATTR_STRING: number;
+  TF_ATTR_INT: number;
+  TF_ATTR_FLOAT: number;
+  TF_ATTR_BOOL: number;
+  TF_ATTR_TYPE: number;
+  TF_ATTR_SHAPE: number;
+  TF_ATTR_TENSOR: number;
+  TF_ATTR_PLACEHOLDER: number;
+  TF_ATTR_FUNC: number;
 
-export function execute(
-    context: Context, op: string, op_attrs: TFEOpAttr[], inputs: TensorHandle[],
-    output: TensorHandle): void;
+  TF_Version: string;
+
+  execute(
+      context: Context, op: string, op_attrs: TFEOpAttr[],
+      inputs: TensorHandle[], output: TensorHandle): void;
+}

--- a/src/tfjs_binding_test.ts
+++ b/src/tfjs_binding_test.ts
@@ -17,7 +17,8 @@
 
 // tslint:disable-next-line:no-require-imports
 import bindings = require('bindings');
-const binding = bindings('tfjs_binding.node');
+import {TFJSBinding} from './tfjs_binding';
+const binding = bindings('tfjs_binding.node') as TFJSBinding;
 
 describe('Exposes TF_DataType enum values', () => {
   it('contains TF_FLOAT', () => {
@@ -68,9 +69,7 @@ describe('Exposes TF Version', () => {
 });
 
 describe('Context', () => {
-  it('Should throw an error if not a Constructor', () => {
-    expect(() => {
-      binding.Context();
-    }).toThrowError();
+  it('creates an instance', () => {
+    expect(new binding.Context()).toBeDefined();
   });
 });


### PR DESCRIPTION
Enables some typing on the binding to be enforced. Reduces the need to
test constructor-type calls amongst other things in the binding. Also
rename data() to dataSync() per the design review.