### PR TITLE
Use a little less memory by batching image creation into one tensor.

### DIFF
--- a/demo/src/mnist_data.ts
+++ b/demo/src/mnist_data.ts
@@ -143,7 +143,7 @@ export class MnistDataset {
     const images = new Float32Array(sizeFromShape(imagesShape));
 
     // Labels must be converted to one-hot, do so through each iteration
-    let label = null as dl.Tensor2D;
+    let label: dl.Tensor2D;
 
     let imageOffset = 0;
     while (this.batchIndex < size) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/47)
<!-- Reviewable:end -->
