### PR TITLE
Fix linux build and add a TODO for darwin builds.

### DIFF
--- a/scripts/download-libtensorflow.sh
+++ b/scripts/download-libtensorflow.sh
@@ -1,21 +1,17 @@
 #!/bin/sh
 
+# TODO(kreeger): Use TF 1.8 builds.
 CPU_DARWIN="http://ci.tensorflow.org/view/Nightly/job/nightly-libtensorflow/TYPE=mac-slave/lastSuccessfulBuild/artifact/lib_package/libtensorflow-cpu-darwin-x86_64.tar.gz"
-GPU_LINUX="http://ci.tensorflow.org/view/Nightly/job/nightly-libtensorflow/TYPE=gpu-linux/lastSuccessfulBuild/artifact/lib_package/libtensorflow-gpu-linux-x86_64.tar.gz"
-# TODO(kreeger): Use nightly links when Jenkins TF uses an updated bazel.
+
 # Build new package:
-# `bazel build --config opt //tensorflow/tools/lib_package:libtensorflow`
-CPU_LINUX="https://storage.googleapis.com/tf-buiilds/libtensorflow.tar.gz"
-# CPU_LINUX="http://ci.tensorflow.org/view/Nightly/job/nightly-libtensorflow/TYPE=cpu-slave/lastSuccessfulBuild/artifact/lib_package/libtensorflow-cpu-linux-x86_64.tar.gz"
+# `bazel build //tensorflow/tools/lib_package:libtensorflow`
+CPU_LINUX="https://storage.googleapis.com/tf-buiilds/libtensorflow_r1_8.tar.gz"
 
 target=""
 platform=$1
 if [ "$platform" = "linux-cpu" ]
 then
   target=$CPU_LINUX
-elif [ "$platform" = "linux-gpu" ]
-then
-  target=$GPU_LINUX
 elif [ "$platform" = "darwin" ]
 then
   target=$CPU_DARWIN


### PR DESCRIPTION
I spun some new builds on a Debian machine at home. The should work for Ubuntu 16.04 and higher. Ubuntu 14 might be hard to support w/o letting users roll their own.

I'll add a script that automates this for people later this week https://github.com/tensorflow/tensorflow/issues/15777

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/71)
<!-- Reviewable:end -->
