### PR TITLE
Implement tf.fromPixels when using the 'tensorflow' backend

### DIFF
--- a/src/canvas_test.ts
+++ b/src/canvas_test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {expectArraysEqual} from '@tensorflow/tfjs-core/dist/test_util';
+
+class MockContext {
+  getImageData(x: number, y: number, width: number, height: number) {
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < data.length; ++i) {
+      data[i] = i + 1;
+    }
+    return {data};
+  }
+}
+
+class MockCanvas {
+  constructor(public width: number, public height: number) {}
+  getContext(type: '2d'): MockContext {
+    return new MockContext();
+  }
+}
+
+describe('tf.fromPixels', () => {
+  it('accepts a canvas-like element', () => {
+    const c = new MockCanvas(2, 2);
+    // tslint:disable-next-line:no-any
+    const t = tf.fromPixels(c as any);
+    expect(t.dtype).toBe('int32');
+    expect(t.shape).toEqual([2, 2, 3]);
+    expectArraysEqual(t, [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
+  });
+
+  it('accepts a canvas-like element, numChannels=4', () => {
+    const c = new MockCanvas(2, 2);
+    // tslint:disable-next-line:no-any
+    const t = tf.fromPixels(c as any, 4);
+    expect(t.dtype).toBe('int32');
+    expect(t.shape).toEqual([2, 2, 4]);
+    expectArraysEqual(
+        t, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  });
+
+  it('errors when passed a non-canvas object', () => {
+    const c = 5;
+    // tslint:disable-next-line:no-any
+    expect(() => tf.fromPixels(c as any))
+        .toThrowError(
+            /When running in node, pixels must be an HTMLCanvasElement/);
+  });
+});

--- a/src/canvas_test.ts
+++ b/src/canvas_test.ts
@@ -16,7 +16,6 @@
  */
 
 import * as tf from '@tensorflow/tfjs-core';
-import {expectArraysEqual} from '@tensorflow/tfjs-core/dist/test_util';
 
 class MockContext {
   getImageData(x: number, y: number, width: number, height: number) {
@@ -42,7 +41,8 @@ describe('tf.fromPixels', () => {
     const t = tf.fromPixels(c as any);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 3]);
-    expectArraysEqual(t, [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
+    tf.test_util.expectArraysEqual(
+        t, [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
   });
 
   it('accepts a canvas-like element, numChannels=4', () => {
@@ -51,7 +51,7 @@ describe('tf.fromPixels', () => {
     const t = tf.fromPixels(c as any, 4);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 4]);
-    expectArraysEqual(
+    tf.test_util.expectArraysEqual(
         t, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
   });
 


### PR DESCRIPTION
Implements tf.fromPixels() by allowing users to pass an object that satisfies the HTMLCanvasElement interface, as the one returned by the 'canvas' npm package. See unit test for user-code.

This PR along with https://github.com/tensorflow/tfjs-core/pull/1127 fixes https://github.com/tensorflow/tfjs/issues/298.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/105)
<!-- Reviewable:end -->
