### PR TITLE
Avoid using deprecated Buffer() constructor

### DIFF
--- a/src/io/file_system.ts
+++ b/src/io/file_system.ts
@@ -128,7 +128,7 @@ export class NodeFileSystem implements tfc.io.IOHandler {
               throw new Error(`Weight file ${
                   weightFilePath} does not exist: loading failed`);
             }
-            const buffer = new Buffer(await readFile(weightFilePath));
+            const buffer = await readFile(weightFilePath);
             buffers.push(buffer);
           }
           weightSpecs.push(...group.weights);

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -21,7 +21,7 @@ import * as tfc from '@tensorflow/tfjs-core';
  * Convert an ArrayBuffer to a Buffer.
  */
 export function toBuffer(ab: ArrayBuffer): Buffer {
-  const buf = new Buffer(ab.byteLength);
+  const buf = Buffer.alloc(ab.byteLength);
   const view = new Uint8Array(ab);
   view.forEach((value, i) => {
     buf[i] = value;

--- a/src/io/io_utils_test.ts
+++ b/src/io/io_utils_test.ts
@@ -27,14 +27,14 @@ describe('toBuffer', () => {
 
 describe('toArrayBuffer', () => {
   it('Single Buffer', () => {
-    const buf = new Buffer([10, 20, 30]);
+    const buf = Buffer.from([10, 20, 30]);
     const ab = toArrayBuffer(buf);
     expect(new Uint8Array(ab)).toEqual(new Uint8Array([10, 20, 30]));
   });
 
   it('Two Buffers', () => {
-    const buf1 = new Buffer([10, 20, 30]);
-    const buf2 = new Buffer([40, 50, 60]);
+    const buf1 = Buffer.from([10, 20, 30]);
+    const buf2 = Buffer.from([40, 50, 60]);
     const ab = toArrayBuffer([buf1, buf2]);
     expect(new Uint8Array(ab)).toEqual(new Uint8Array([
       10, 20, 30, 40, 50, 60
@@ -42,9 +42,9 @@ describe('toArrayBuffer', () => {
   });
 
   it('Three Buffers', () => {
-    const buf1 = new Buffer([10, 20, 30]);
-    const buf2 = new Buffer([40, 50, 60]);
-    const buf3 = new Buffer([3, 2, 1]);
+    const buf1 = Buffer.from([10, 20, 30]);
+    const buf2 = Buffer.from([40, 50, 60]);
+    const buf3 = Buffer.from([3, 2, 1]);
     const ab = toArrayBuffer([buf1, buf2, buf3]);
     expect(new Uint8Array(ab)).toEqual(new Uint8Array([
       10, 20, 30, 40, 50, 60, 3, 2, 1


### PR DESCRIPTION
`fs.readFile` already returns a Buffer if no encoding is specified, there is no need to wrap it in another `new Buffer()` call.

Other `new Buffer()` calls were replaced with `Buffer.from()` or `Buffer.alloc()`.

All current Node.js branches support `Buffer.from`/`Buffer.alloc`, starting with Node.js v4.5.0/5.10.0 (which already reached EOL).

This fixes the `[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.` deprecation warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/109)
<!-- Reviewable:end -->
