### PR TITLE
Minor toBuffer/toArrayBuffer cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@tensorflow/tfjs-core": "~0.11.9",
     "@types/bindings": "~1.3.0",
     "@types/jasmine": "~2.8.6",
-    "@types/node": "~9.6.2",
+    "@types/node": "^10.5.1",
     "@types/rimraf": "~2.0.2",
     "clang-format": "~1.2.2",
     "jasmine": "~3.1.0",

--- a/src/io/file_system_test.ts
+++ b/src/io/file_system_test.ts
@@ -22,8 +22,6 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 import {promisify} from 'util';
 
-import {toBuffer} from './io_utils';
-
 describe('File system IOHandler', () => {
   const mkdtemp = promisify(fs.mkdtemp);
   const readFile = promisify(fs.readFile);
@@ -199,7 +197,7 @@ describe('File system IOHandler', () => {
         Buffer.from(new Float32Array([-1.1, -3.3, -3.3]).buffer);
     await writeFile(
         path.join(testDir, 'weights.1.bin'), weightsData1, 'binary');
-    const weightsData2 = toBuffer(new Float32Array([-7.7]).buffer);
+    const weightsData2 = Buffer.from(new Float32Array([-7.7]).buffer);
     await writeFile(
         path.join(testDir, 'weights.2.bin'), weightsData2, 'binary');
 

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -21,12 +21,8 @@ import * as tfc from '@tensorflow/tfjs-core';
  * Convert an ArrayBuffer to a Buffer.
  */
 export function toBuffer(ab: ArrayBuffer): Buffer {
-  const buf = Buffer.alloc(ab.byteLength);
   const view = new Uint8Array(ab);
-  view.forEach((value, i) => {
-    buf[i] = value;
-  });
-  return buf;
+  return Buffer.from(view); // copies data
 }
 
 /**

--- a/src/io/io_utils.ts
+++ b/src/io/io_utils.ts
@@ -35,27 +35,20 @@ export function toArrayBuffer(buf: Buffer|Buffer[]): ArrayBuffer {
   if (Array.isArray(buf)) {
     // An Array of Buffers.
     let totalLength = 0;
-    buf.forEach(buffer => {
+    for (const buffer of buf) {
       totalLength += buffer.length;
-    });
+    }
 
     const ab = new ArrayBuffer(totalLength);
     const view = new Uint8Array(ab);
     let pos = 0;
-    buf.forEach(buffer => {
-      for (let i = 0; i < buffer.length; ++i) {
-        view[pos++] = buffer[i];
-      }
-    });
-    return ab;
-  } else {
-    // A single Buffer.
-    const ab = new ArrayBuffer(buf.length);
-    const view = new Uint8Array(ab);
-    for (let i = 0; i < buf.length; ++i) {
-      view[i] = buf[i];
+    for (const buffer of buf) {
+      pos += buffer.copy(view, pos);
     }
     return ab;
+  } else {
+    // A single Buffer. Return a copy of the underlying ArrayBuffer slice.
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
   }
 }
 


### PR DESCRIPTION
See detailed description of changes in commit messages.

This both reduces the number of lines and should optimize those methods a bit in some cases.

`NodeFileSystem#save(:tfc.io.ModelArtifacts)` still uses copying, but while changing that is a two-liner, there could be some more questions there (e.g. should `toBuffer` be kept or not in that case), so I would prefer to land this first as everything seems straightforward here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/111)
<!-- Reviewable:end -->
