### PR TITLE
file_system: group promisify, avoid relying on in-advance fs.exists checks

### DIFF
--- a/src/io/file_system.ts
+++ b/src/io/file_system.ts
@@ -151,15 +151,21 @@ export class NodeFileSystem implements tfc.io.IOHandler {
    * that the path exists as a directory.
    */
   protected async createOrVerifyDirectory() {
-    for (const path of Array.isArray(this.path) ? this.path : [this.path]) {
-      if (await exists(path)) {
-        if ((await stat(path)).isFile()) {
-          throw new Error(
+    const paths = Array.isArray(this.path) ? this.path : [this.path];
+    for (const path of paths) {
+      try {
+        await mkdir(path);
+      } catch (e) {
+        if (e.code === 'EEXIST') {
+          if ((await stat(path)).isFile()) {
+            throw new Error(
               `Path ${path} exists as a file. The path must be ` +
               `nonexistent or point to a directory.`);
+          }
+          // else continue, the directory exists
+        } else {
+          throw e;
         }
-      } else {
-        await mkdir(path);
       }
     }
   }


### PR DESCRIPTION
Again several commits here with their own descriptions.

This removes `fs.exists` usage and does some minor cleanup.
My intention was to remove the in-advance checks that might result in a race.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/112)
<!-- Reviewable:end -->
