### PR TITLE
Specify minimum supporting node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ TensorFlow.js for Node currently supports the following platforms:
 - Mac OS X CPU (10.12.6 Siera or higher)
 - Linux CPU (Ubuntu 16.04 or higher)
 - Linux GPU (Ubuntu 16.04 or higher and Cuda 9.0 w/ CUDNN v7) ([see installation instructions](https://www.tensorflow.org/install/install_linux))
+- Node.js (>= 9.6.0)
 
 *Other Linux variants might also work but this project matches [core TensorFlow installation requirements](https://www.tensorflow.org/install/install_linux).*
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/tensorflow/tfjs-node.git"
   },
+  "engines": {
+    "node": ">=9.6.0"
+  },
   "scripts": {
     "prep": "cd node_modules/@tensorflow/tfjs-core && yarn && yarn build",
     "build": "tsc",


### PR DESCRIPTION
I found tfjs-node uses unsupported N-API before 9.5.0. We need to specify the minimum required version of node.js. 9.6.0 supports all N-APIs used by tfjs-node. 

```
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  ACTION binding_gyp_tfjs_binding_target_download_libtensorflow Release/libtensorflow.so
  CXX(target) Release/obj.target/tfjs_binding/binding/tfe_utils.o
In file included from ../binding/tfe_utils.cc:30:
../binding/utils.h:97:25: error: use of undeclared identifier 'napi_get_new_target'
  napi_status nstatus = napi_get_new_target(env, info, &js_target);
                        ^
1 error generated.
make: *** [Release/obj.target/tfjs_binding/binding/tfe_utils.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/sasakikai/.nvm/versions/node/v8.5.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:258:23)
gyp ERR! stack     at emitTwo (events.js:125:13)
gyp ERR! stack     at ChildProcess.emit (events.js:213:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Darwin 17.6.0
gyp ERR! command "/Users/sasakikai/.nvm/versions/node/v8.5.0/bin/node" "/Users/sasakikai/.nvm/versions/node/v8.5.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/sasakikai/dev/tfjs-node
gyp ERR! node -v v8.5.0
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/114)
<!-- Reviewable:end -->
