### PR TITLE
Use Buffer.from instead of toBuffer() in save(modelArtifacts)

### DIFF
--- a/src/io/file_system.ts
+++ b/src/io/file_system.ts
@@ -21,7 +21,7 @@ import {dirname, join, resolve} from 'path';
 import {promisify} from 'util';
 
 // tslint:disable-next-line:max-line-length
-import {getModelArtifactsInfoForJSON, toArrayBuffer, toBuffer} from './io_utils';
+import {getModelArtifactsInfoForJSON, toArrayBuffer} from './io_utils';
 
 export class NodeFileSystem implements tfc.io.IOHandler {
   static readonly URL_SCHEME = 'file://';
@@ -84,7 +84,7 @@ export class NodeFileSystem implements tfc.io.IOHandler {
       const writeFile = promisify(fs.writeFile);
       await writeFile(modelJSONPath, JSON.stringify(modelJSON), 'utf8');
       await writeFile(
-          weightsBinPath, toBuffer(modelArtifacts.weightData), 'binary');
+          weightsBinPath, Buffer.from(modelArtifacts.weightData), 'binary');
 
       return {
         // TODO(cais): Use explicit tfc.io.ModelArtifactsInfo type below once it


### PR DESCRIPTION
Replace call to `io_utils.toBuffer(arrayBuffer)` with `Buffer.from(arrayBuffer)`.

This changes the behavior of that code.

The difference is that `Buffer.from(arrayBuffer)` does not perform copying of the underlying data and just sets up a view on top on the underlying ArrayBuffer, but `Buffer.from(uint8Array)` (used in `io_utils.toBuffer`) performs copying.

It's safe to not perform copying when the underlying data is not changed, and it is faster.

Refs: https://github.com/tensorflow/tfjs-node/pull/109#issuecomment-401432688, [Buffer.from(arrayBuffer)](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length), [Buffer.from(uint8Array)](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_buffer).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/117)
<!-- Reviewable:end -->
