### PR TITLE
test_node: throw on unhandled promise rejections

### DIFF
--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -28,6 +28,8 @@ import bindings = require('bindings');
 import {TFJSBinding} from './tfjs_binding';
 import {NodeJSKernelBackend} from './nodejs_kernel_backend';
 
+process.on('unhandledRejection', e => { throw e; });
+
 jasmine_util.setTestEnvs([{
   name: 'test-tensorflow',
   factory: () =>


### PR DESCRIPTION
This makes 'test' script treat unhandled rejections as errors.

Refs: https://github.com/tensorflow/tfjs-core/pull/1152
Refs: https://nodejs.org/api/process.html#process_event_unhandledrejection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/118)
<!-- Reviewable:end -->
