### PR TITLE
Expose the binding internally.

### DIFF
--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -31,7 +31,7 @@ type TensorInfo = {
 interface DataId {}
 
 export class NodeJSKernelBackend implements KernelBackend {
-  private binding: TFJSBinding;
+  binding: TFJSBinding;
   private tensorMap = new WeakMap<DataId, TensorInfo>();
 
   constructor(binding: TFJSBinding) {

--- a/src/ops/op_utils_test.ts
+++ b/src/ops/op_utils_test.ts
@@ -24,4 +24,8 @@ describe('Exposes Backend for internal Op execution.', () => {
     const backend = nodeBackend();
     expect(backend instanceof NodeJSKernelBackend).toBeTruthy();
   });
+
+  it('Provides internal access to the binding', () => {
+    expect(nodeBackend().binding).toBeDefined();
+  });
 });


### PR DESCRIPTION
This will be needed for Op attribute construction.