### PR TITLE
Add/move TF binding methods to op_utils.ts

### DIFF
--- a/src/ops/op_utils.ts
+++ b/src/ops/op_utils.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {isArray} from 'util';
+import {isArray, isNullOrUndefined} from 'util';
 
 import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
 import {TFEOpAttr} from '../tfjs_binding';
@@ -53,6 +53,9 @@ export function createTypeOpAttr(
 
 /** Returns the dtype number for a single or list of input Tensors. */
 export function getTFDTypeForInputs(tensors: tfc.Tensor|tfc.Tensor[]): number {
+  if (isNullOrUndefined(tensors)) {
+    throw new Error('Invalid input tensors value.');
+  }
   if (isArray(tensors)) {
     for (let i = 0; i < tensors.length; i++) {
       return getTFDType(tensors[i].dtype);

--- a/src/ops/op_utils.ts
+++ b/src/ops/op_utils.ts
@@ -16,9 +16,49 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
+import {isArray} from 'util';
+
 import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
+import {TFEOpAttr} from '../tfjs_binding';
 
 /** Returns an instance of the Node.js backend. */
 export function nodeBackend(): NodeJSKernelBackend {
   return (tfc.ENV.findBackend('tensorflow') as NodeJSKernelBackend);
+}
+
+/** Returns the TF dtype for a given DataType. */
+export function getTFDType(dataType: tfc.DataType): number {
+  const binding = nodeBackend().binding;
+  switch (dataType) {
+    case 'float32':
+      return binding.TF_FLOAT;
+    case 'int32':
+      return binding.TF_INT32;
+    case 'bool':
+      return binding.TF_BOOL;
+    default:
+      throw new Error('Unknown dtype `${dtype}`');
+  }
+}
+
+/** Creates a TFEOpAttr for a 'type' OpDef attribute. */
+export function createTypeOpAttr(
+    attrName: string, dtype: tfc.DataType): TFEOpAttr {
+  return {
+    name: attrName,
+    type: nodeBackend().binding.TF_ATTR_TYPE,
+    value: getTFDType(dtype)
+  };
+}
+
+/** Returns the dtype number for a single or list of input Tensors. */
+export function getTFDTypeForInputs(tensors: tfc.Tensor|tfc.Tensor[]): number {
+  if (isArray(tensors)) {
+    for (let i = 0; i < tensors.length; i++) {
+      return getTFDType(tensors[i].dtype);
+    }
+    return -1;
+  } else {
+    return getTFDType(tensors.dtype);
+  }
 }

--- a/src/ops/op_utils_test.ts
+++ b/src/ops/op_utils_test.ts
@@ -17,7 +17,7 @@
 
 import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
 
-import {nodeBackend} from './op_utils';
+import {getTFDType, nodeBackend} from './op_utils';
 
 describe('Exposes Backend for internal Op execution.', () => {
   it('Provides the Node backend over a function', () => {
@@ -27,5 +27,22 @@ describe('Exposes Backend for internal Op execution.', () => {
 
   it('Provides internal access to the binding', () => {
     expect(nodeBackend().binding).toBeDefined();
+  });
+});
+
+describe('TFJS binding dtypes for Tensors', () => {
+  const binding = nodeBackend().binding;
+
+  it('handles float32', () => {
+    expect(getTFDType('float32')).toBe(binding.TF_FLOAT);
+  });
+  it('handles int32', () => {
+    expect(getTFDType('int32')).toBe(binding.TF_INT32);
+  });
+  it('handles bool', () => {
+    expect(getTFDType('bool')).toBe(binding.TF_BOOL);
+  });
+  it('handles unknown types', () => {
+    expect(() => getTFDType(null)).toThrowError();
   });
 });

--- a/src/ops/op_utils_test.ts
+++ b/src/ops/op_utils_test.ts
@@ -17,7 +17,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 
-import {getLoadHandlers} from '../../node_modules/@tensorflow/tfjs-core/dist/io/io';
 import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
 
 // tslint:disable-next-line:max-line-length


### PR DESCRIPTION
This PR moves common methods that are currently private in the Node.js backend to op_utils.ts. It also introduces a new method to return the TF dtype binding value for a Tensor or list of Tensors.

These new methods will be needed for upcoming generated code from core TensorFlow. Generated code will rely on these methods to properly set up calls into the binding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/125)
<!-- Reviewable:end -->
