### PR TITLE
Don't create the binding every test.

### DIFF
--- a/src/ops/op_utils.ts
+++ b/src/ops/op_utils.ts
@@ -21,9 +21,14 @@ import {isArray, isNullOrUndefined} from 'util';
 import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
 import {TFEOpAttr} from '../tfjs_binding';
 
+let gBackend: NodeJSKernelBackend = null;
+
 /** Returns an instance of the Node.js backend. */
 export function nodeBackend(): NodeJSKernelBackend {
-  return (tfc.ENV.findBackend('tensorflow') as NodeJSKernelBackend);
+  if (gBackend === null) {
+    gBackend = (tfc.ENV.findBackend('tensorflow') as NodeJSKernelBackend);
+  }
+  return gBackend;
 }
 
 /** Returns the TF dtype for a given DataType. */

--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -22,22 +22,15 @@ Error.stackTraceLimit = Infinity;
 
 // tslint:disable-next-line:no-require-imports
 const jasmineCtor = require('jasmine');
-
 // tslint:disable-next-line:no-require-imports
-import bindings = require('bindings');
-import {TFJSBinding} from './tfjs_binding';
-import {NodeJSKernelBackend} from './nodejs_kernel_backend';
+import {nodeBackend} from './ops/op_utils';
 
 process.on('unhandledRejection', e => {
   throw e;
 });
 
-jasmine_util.setTestEnvs([{
-  name: 'test-tensorflow',
-  factory: () =>
-      new NodeJSKernelBackend(bindings('tfjs_binding.node') as TFJSBinding),
-  features: {}
-}]);
+jasmine_util.setTestEnvs(
+    [{name: 'test-tensorflow', factory: () => nodeBackend(), features: {}}]);
 
 const IGNORE_LIST: string[] = [
   // See https://github.com/tensorflow/tfjs/issues/161
@@ -72,6 +65,6 @@ env.specFilter = spec => {
 };
 
 // TODO(kreeger): Consider moving to C-code.
-console.log(`Running tests against TensorFlow: ${
-    (bindings('tfjs_binding.node') as TFJSBinding).TF_Version}`);
+console.log(
+    `Running tests against TensorFlow: ${nodeBackend().binding.TF_Version}`);
 runner.execute();


### PR DESCRIPTION
Currently, the binding is re-loaded for every unit test. This doesn't really re-create the environment the binding is used in. Also, this causes race conditions looking up the Tensor backend through `ENV.findBackend('tensorflow')` in generated code.

This PR does two things:
1.) Uses the same NodeJSBackend for every test.
2.) Caches the backend loaded trough the utility method `nodeBackend()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/127)
<!-- Reviewable:end -->
