### PR TITLE
Export NodeFileSystem handler as tjsNode.io.NodeFileSystem

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@
 import * as tfc from '@tensorflow/tfjs-core';
 
 import {nodeFileSystemRouter} from './io/file_system';
+import * as io from './io/index';
 import {NodeJSKernelBackend} from './nodejs_kernel_backend';
 
 // tslint:disable-next-line:no-require-imports
@@ -38,3 +39,4 @@ tfc.io.registerSaveRouter(nodeFileSystemRouter);
 tfc.io.registerLoadRouter(nodeFileSystemRouter);
 
 export {version} from './version';
+export {io};

--- a/src/io/file_system_test.ts
+++ b/src/io/file_system_test.ts
@@ -22,6 +22,8 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 import {promisify} from 'util';
 
+import * as tfn from '../index';
+
 describe('File system IOHandler', () => {
   const mkdtemp = promisify(fs.mkdtemp);
   const readFile = promisify(fs.readFile);
@@ -292,5 +294,11 @@ describe('File system IOHandler', () => {
               .toMatch(/Weight file .*weights\.2\.bin does not exist/);
           done();
         });
+  });
+
+  it('Exported file-system handler class exists', () => {
+    const handler = new tfn.io.NodeFileSystem(testDir);
+    expect(typeof handler.save).toEqual('function');
+    expect(typeof handler.load).toEqual('function');
   });
 });

--- a/src/io/index.ts
+++ b/src/io/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * Public exports from the `io` module.
+ */
+
+export {NodeFileSystem} from './file_system';


### PR DESCRIPTION
Justification

1. Required by an integration test for tfjs-keras interoperability
   in tfjs-layers.
2. Can be potentially useful for clients who wish to inherit from
   this class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/128)
<!-- Reviewable:end -->
