### PR TITLE
Use strict version for tfjs-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish-local": "yarn prep && yarn build && yalc push"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~0.12.1",
+    "@tensorflow/tfjs-core": "0.12.1",
     "@types/bindings": "~1.3.0",
     "@types/jasmine": "~2.8.6",
     "@types/node": "^10.5.1",
@@ -39,6 +39,6 @@
     "bindings": "~1.3.0"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~0.12.1"
+    "@tensorflow/tfjs-core": "0.12.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,7 +82,7 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@tensorflow/tfjs-core@~0.12.1":
+"@tensorflow/tfjs-core@0.12.1":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.1.tgz#3d83f5676900b815a09cf8baa77862369e26f9bb"
   dependencies:


### PR DESCRIPTION
Use strict version for tfjs-core. This is a quick fix for tensorflow/tfjs#560. Another PR support new ops is on the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/130)
<!-- Reviewable:end -->
