### PR TITLE
Cleanup binding.gyp actions for windows, mac, and linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -41,7 +41,24 @@
           'library_dirs' : ['<(PRODUCT_DIR)'],
           'variables': {
             'tensorflow-library-target': 'linux-cpu'
-          }
+          },
+          'actions': [
+            {
+              'action_name': 'get_libtensorflow',
+              'inputs': [
+                '<(module_root_dir)/scripts/get_libtensorflow.js'
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/libtensorflow.so',
+              ],
+              'action': [
+                'node',
+                '<@(_inputs)',
+                '<(tensorflow-library-target)',
+                '<(PRODUCT_DIR)',
+              ]
+            }
+          ],
         }
       ],
       [
@@ -53,7 +70,24 @@
           'library_dirs' : ['<(PRODUCT_DIR)'],
           'variables': {
             'tensorflow-library-target': 'darwin'
-          }
+          },
+          'actions': [
+            {
+              'action_name': 'get_libtensorflow',
+              'inputs': [
+                '<(module_root_dir)/scripts/get_libtensorflow.js'
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/libtensorflow.so',
+              ],
+              'action': [
+                'node',
+                '<@(_inputs)',
+                '<(tensorflow-library-target)',
+                '<(PRODUCT_DIR)',
+              ]
+            }
+          ],
         }
       ],
       [
@@ -66,10 +100,26 @@
           },
           'actions': [
             {
+              'action_name': 'get_libtensorflow',
+              'inputs': [
+                '<(module_root_dir)/scripts/get_libtensorflow.js'
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/tensorflow.dll',
+              ],
+              'action': [
+                'node',
+                '<@(_inputs)',
+                '<(tensorflow-library-target)',
+                '<(PRODUCT_DIR)',
+              ]
+            },
+            {
               'action_name': 'generate_def',
               'inputs': [
                 '<(module_root_dir)/scripts/generate_defs.js',
-                '<@(tensorflow_headers)'
+                '<@(tensorflow_headers)',
+                "<(PRODUCT_DIR)/tensorflow.dll"
               ],
               'outputs': [
                 '<(INTERMEDIATE_DIR)/tensorflow.def'
@@ -97,23 +147,6 @@
           ],
         },
       ]
-    ],
-    'actions': [
-      {
-        'action_name': 'get_libtensorflow',
-        'inputs': [
-          '<(module_root_dir)/scripts/get_libtensorflow.js'
-        ],
-        'outputs': [
-          '<(PRODUCT_DIR)/libtensorflow.so',
-        ],
-        'action': [
-          'node',
-          '<@(_inputs)',
-          '<(tensorflow-library-target)',
-          '<(PRODUCT_DIR)',
-        ]
-      }
     ],
   }]
 }

--- a/scripts/get_libtensorflow.js
+++ b/scripts/get_libtensorflow.js
@@ -51,7 +51,7 @@ if (platform === 'linux-cpu') {
   libName = 'tensorflow.dll';
 
   // Some windows machines contain a trailing " char:
-  if (targetDir.endsWith('"')) {
+  if (targetDir != undefined && targetDir.endsWith('"')) {
     targetDir = targetDir.substr(0, targetDir.length - 1);
   }
 


### PR DESCRIPTION
Windows needs to have specific outputs to ensure that the actions run in order. This PR moves actions into each build group. I kept the `tensorflow-library-target` rule since the build-npm script uses `sed` to easily replace that for GPU builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/137)
<!-- Reviewable:end -->
