### PR TITLE
Ignore two tests on Windows

### DIFF
--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -39,6 +39,7 @@ let IGNORE_LIST: string[] = [
 ];
 
 // Windows has two failing tests:
+// https://github.com/tensorflow/tfjs/issues/598
 if (process.platform === 'win32') {
   IGNORE_LIST.push('clip test-tensorflow {} propagates NaNs');
   IGNORE_LIST.push(

--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -32,11 +32,18 @@ process.on('unhandledRejection', e => {
 jasmine_util.setTestEnvs(
     [{name: 'test-tensorflow', factory: () => nodeBackend(), features: {}}]);
 
-const IGNORE_LIST: string[] = [
+let IGNORE_LIST: string[] = [
   // See https://github.com/tensorflow/tfjs/issues/161
   'depthwiseConv2D',  // Requires space_to_batch() for dilation > 1.
   'separableConv2d',  // Requires space_to_batch() for dilation > 1.
 ];
+
+// Windows has two failing tests:
+if (process.platform === 'win32') {
+  IGNORE_LIST.push('clip test-tensorflow {} propagates NaNs');
+  IGNORE_LIST.push(
+      'maxPool test-tensorflow {} [x=[3,3,1] f=[2,2] s=1 ignores NaNs');
+}
 
 const runner = new jasmineCtor();
 runner.loadConfig({

--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -32,7 +32,7 @@ process.on('unhandledRejection', e => {
 jasmine_util.setTestEnvs(
     [{name: 'test-tensorflow', factory: () => nodeBackend(), features: {}}]);
 
-let IGNORE_LIST: string[] = [
+const IGNORE_LIST: string[] = [
   // See https://github.com/tensorflow/tfjs/issues/161
   'depthwiseConv2D',  // Requires space_to_batch() for dilation > 1.
   'separableConv2d',  // Requires space_to_batch() for dilation > 1.


### PR DESCRIPTION
Windows appears to have two failing `NaN` tests: https://github.com/tensorflow/tfjs/issues/598

Add a special Windows-only Ignore list for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/140)
<!-- Reviewable:end -->
