### PR TITLE
Add command for optional node-gyp rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "ts-node src/run_tests.ts",
     "coverage": "nyc ts-node src/run_tests.ts",
     "link-local": "yalc link",
-    "publish-local": "yarn prep && yarn build && yalc push"
+    "publish-local": "yarn prep && yarn build && yalc push",
+    "install": "node-gyp rebuild || exit 0"
   },
   "devDependencies": {
     "@tensorflow/tfjs-core": "~0.12.10",


### PR DESCRIPTION
I found this command so that if `node-gyp rebuild` failed, it would still return success and continue the following scripts. I tried with compile both cpu and gpu packages in mac and install tfjs-node-gpu from packed "tensorflow-tfjs-node-gpu-0.1.12.tgz", it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/148)
<!-- Reviewable:end -->
