### PR TITLE
Create cleaner createTensorsTypeOpAttr() method for generated Op code.

### DIFF
--- a/src/ops/op_utils.ts
+++ b/src/ops/op_utils.ts
@@ -46,7 +46,10 @@ export function getTFDType(dataType: tfc.DataType): number {
   }
 }
 
-/** Creates a TFEOpAttr for a 'type' OpDef attribute. */
+/**
+ * Creates a TFEOpAttr for a 'type' OpDef attribute.
+ * @deprecated Please use createTensorsTypeOpAttr() going forward.
+ */
 export function createTypeOpAttr(
     attrName: string, dtype: tfc.DataType): TFEOpAttr {
   return {
@@ -56,8 +59,24 @@ export function createTypeOpAttr(
   };
 }
 
+/**
+ * Creates a TFEOpAttr for a 'type' OpDef attribute from a Tensor or list of
+ * Tensors.
+ */
+export function createTensorsTypeOpAttr(
+    attrName: string, tensors: tfc.Tensor|tfc.Tensor[]) {
+  if (isNullOrUndefined(tensors)) {
+    throw new Error('Invalid input tensors value.');
+  }
+  return {
+    name: attrName,
+    type: nodeBackend().binding.TF_ATTR_TYPE,
+    value: getTFDTypeForInputs(tensors)
+  };
+}
+
 /** Returns the dtype number for a single or list of input Tensors. */
-export function getTFDTypeForInputs(tensors: tfc.Tensor|tfc.Tensor[]): number {
+function getTFDTypeForInputs(tensors: tfc.Tensor|tfc.Tensor[]): number {
   if (isNullOrUndefined(tensors)) {
     throw new Error('Invalid input tensors value.');
   }

--- a/src/ops/op_utils_test.ts
+++ b/src/ops/op_utils_test.ts
@@ -20,7 +20,7 @@ import * as tfc from '@tensorflow/tfjs-core';
 import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
 
 // tslint:disable-next-line:max-line-length
-import {createTypeOpAttr, getTFDType, getTFDTypeForInputs, nodeBackend} from './op_utils';
+import {createTensorsTypeOpAttr, createTypeOpAttr, getTFDType, nodeBackend} from './op_utils';
 
 describe('Exposes Backend for internal Op execution.', () => {
   it('Provides the Node backend over a function', () => {
@@ -65,22 +65,27 @@ describe('createTypeOpAttr()', () => {
   });
 });
 
-describe('Returns TFDtype values for Tensor or list of Tensors', () => {
+describe('Returns TFEOpAttr for a Tensor or list of Tensors', () => {
   const binding = nodeBackend().binding;
 
   it('handles a single Tensor', () => {
-    expect(getTFDTypeForInputs(tfc.scalar(13, 'float32')))
-        .toBe(binding.TF_FLOAT);
+    const result = createTensorsTypeOpAttr('T', tfc.scalar(13, 'float32'));
+    expect(result.name).toBe('T');
+    expect(result.type).toBe(binding.TF_ATTR_TYPE);
+    expect(result.value).toBe(binding.TF_FLOAT);
   });
   it('handles a list of Tensors', () => {
-    const inputs = [tfc.scalar(1, 'int32'), tfc.scalar(20.1, 'float32')];
-    expect(getTFDTypeForInputs(inputs)).toBe(binding.TF_INT32);
+    const tensors = [tfc.scalar(1, 'int32'), tfc.scalar(20.1, 'float32')];
+    const result = createTensorsTypeOpAttr('T', tensors);
+    expect(result.name).toBe('T');
+    expect(result.type).toBe(binding.TF_ATTR_TYPE);
+    expect(result.value).toBe(binding.TF_INT32);
   });
   it('handles null', () => {
-    expect(() => getTFDTypeForInputs(null)).toThrowError();
+    expect(() => createTensorsTypeOpAttr('T', null)).toThrowError();
   });
   it('handles list of null', () => {
     const inputs = [null, null] as tfc.Tensor[];
-    expect(() => getTFDTypeForInputs(inputs)).toThrowError();
+    expect(() => createTensorsTypeOpAttr('T', inputs)).toThrowError();
   });
 });


### PR DESCRIPTION
This refactor will make generated code a little more simple. This method simply figures out the write inputs so methods do not need to be chained in generated code.

For example, w/ generated code - this looks like:
```ts
export function Foo(images: tfc.Tensor[], dim: tfc.Tensor): tfc.Tensor {
  const opAttrs = [
    createTypeOpAttr('T', getTFDTypeForInputs(images)),
  ];
  ...
}
```

With this change, the method looks like:
```ts
export function Foo(images: tfc.Tensor[], dim: tfc.Tensor): tfc.Tensor {
  const opAttrs = [
    createTensorsTypeOpAttr('T', images),
  ];
  ...
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/151)
<!-- Reviewable:end -->
