### PR TITLE
Make ProgbarLogger work for model.fitDataset()

### DIFF
--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -51,7 +51,7 @@ export class ProgbarLogger extends CustomCallback {
               samples != null ? Math.ceil(samples / batchSize) : steps;
         } else {
           // Undetermined number of batches per epoch, e.g., due to
-          // fitDataset() without `batchesPerEpoch`.
+          // `fitDataset()` without `batchesPerEpoch`.
           // TODO(cais): Unit test coverage. DO NOT SUBMIT.
           this.numTrainBatchesPerEpoch = 0;
         }

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -44,14 +44,17 @@ export class ProgbarLogger extends CustomCallback {
       onTrainBegin: async (logs?: Logs) => {
         const samples = this.params.samples as number;
         const batchSize = this.params.batchSize as number;
+        const steps = this.params.steps as number;
         util.assert(
-            samples != null,
-            'ProgbarLogger cannot operate when samples is undefined or null.');
+            samples != null || steps != null,
+            'ProgbarLogger cannot operate when samples and steps are both ' +
+                'undefined or null.');
         util.assert(
-            batchSize != null,
-            'ProgbarLogger cannot operate when batchSize is undefined or ' +
-                'null.');
-        this.numTrainBatchesPerEpoch = Math.ceil(samples / batchSize);
+            batchSize != null || steps != null,
+            'ProgbarLogger cannot operate when batchSize and steps are both ' +
+                ' undefined or null.');
+        this.numTrainBatchesPerEpoch =
+            samples != null ? Math.ceil(samples / batchSize) : steps;
       },
       onEpochBegin: async (epoch: number, logs?: Logs) => {
         progressBarHelper.log(`Epoch ${epoch + 1} / ${this.params.epochs}`);
@@ -69,8 +72,9 @@ export class ProgbarLogger extends CustomCallback {
         await nextFrame();
         if (batch === this.numTrainBatchesPerEpoch - 1) {
           this.epochDurationMillis = util.now() - this.currentEpochBegin;
-          this.usPerStep =
-              this.epochDurationMillis / (this.params.samples as number) * 1e3;
+          this.usPerStep = this.params.samples != null ?
+              this.epochDurationMillis / (this.params.samples as number) * 1e3 :
+              this.epochDurationMillis / 1e3;
         }
       },
       onEpochEnd: async (epoch: number, logs?: Logs) => {

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -35,6 +35,7 @@ export class ProgbarLogger extends CustomCallback {
   private currentEpochBegin: number;
   private epochDurationMillis: number;
   private usPerStep: number;
+  private epochBatches: number;
 
   /**
    * Construtor of LoggingCallback.
@@ -45,39 +46,55 @@ export class ProgbarLogger extends CustomCallback {
         const samples = this.params.samples as number;
         const batchSize = this.params.batchSize as number;
         const steps = this.params.steps as number;
-        util.assert(
-            samples != null || steps != null,
-            'ProgbarLogger cannot operate when samples and steps are both ' +
-                'undefined or null.');
-        util.assert(
-            batchSize != null || steps != null,
-            'ProgbarLogger cannot operate when batchSize and steps are both ' +
-                ' undefined or null.');
-        this.numTrainBatchesPerEpoch =
-            samples != null ? Math.ceil(samples / batchSize) : steps;
+        if (samples != null || steps != null) {
+          this.numTrainBatchesPerEpoch =
+              samples != null ? Math.ceil(samples / batchSize) : steps;
+        } else {
+          // Undetermined number of batches per epoch, e.g., due to
+          // fitDataset() without `batchesPerEpoch`.
+          // TODO(cais): Unit test coverage. DO NOT SUBMIT.
+          this.numTrainBatchesPerEpoch = 0;
+        }
       },
       onEpochBegin: async (epoch: number, logs?: Logs) => {
         progressBarHelper.log(`Epoch ${epoch + 1} / ${this.params.epochs}`);
         this.currentEpochBegin = util.now();
+        this.epochDurationMillis = null;
+        this.usPerStep = null;
+        this.epochBatches = 0;
       },
       onBatchEnd: async (batch: number, logs?: Logs) => {
+        this.epochBatches++;
         if (batch === 0) {
           this.progressBar = new progressBarHelper.ProgressBar(
               'eta=:eta :bar :placeholderForLossesAndMetrics',
               {total: this.numTrainBatchesPerEpoch + 1, head: `>`});
         }
-        this.progressBar.tick({
+        const tickTokens = {
           placeholderForLossesAndMetrics: this.formatLogsAsMetricsContent(logs)
-        });
+        };
+        if (this.numTrainBatchesPerEpoch === 0) {
+          // Undetermined number of batches per epoch.
+          this.progressBar.tick(0, tickTokens);
+        } else {
+          this.progressBar.tick(tickTokens);
+        }
         await nextFrame();
         if (batch === this.numTrainBatchesPerEpoch - 1) {
           this.epochDurationMillis = util.now() - this.currentEpochBegin;
           this.usPerStep = this.params.samples != null ?
               this.epochDurationMillis / (this.params.samples as number) * 1e3 :
-              this.epochDurationMillis / 1e3;
+              this.epochDurationMillis / this.epochBatches * 1e3;
         }
       },
       onEpochEnd: async (epoch: number, logs?: Logs) => {
+        if (this.epochDurationMillis == null) {
+          // In cases where the number of batches per epoch is not determined,
+          // the calculation of the per-step duration is done at the end of the
+          // epoch. N.B., this includes the time spent on validation.
+          this.epochDurationMillis = util.now() - this.currentEpochBegin;
+          this.usPerStep = this.epochDurationMillis / this.epochBatches * 1e3;
+        }
         this.progressBar.tick({placeholderForLossesAndMetrics: ''});
         const lossesAndMetricsString = this.formatLogsAsMetricsContent(logs);
         progressBarHelper.log(

--- a/src/callbacks.ts
+++ b/src/callbacks.ts
@@ -92,7 +92,8 @@ export class ProgbarLogger extends CustomCallback {
           // the calculation of the per-step duration is done at the end of the
           // epoch. N.B., this includes the time spent on validation.
           this.epochDurationMillis = util.now() - this.currentEpochBegin;
-          this.usPerStep = this.epochDurationMillis / this.batchesInLatestEpoch * 1e3;
+          this.usPerStep =
+              this.epochDurationMillis / this.batchesInLatestEpoch * 1e3;
         }
         this.progressBar.tick({placeholderForLossesAndMetrics: ''});
         const lossesAndMetricsString = this.formatLogsAsMetricsContent(logs);

--- a/src/callbacks_test.ts
+++ b/src/callbacks_test.ts
@@ -165,6 +165,66 @@ describe('progbarLogger', () => {
 
     expect(fakeProgbars.length).toEqual(0);
   });
+
+  it('Model.fitDataset: batchesPerEpoch specified, verbose = 1', async () => {
+    const fakeProgbars: FakeProgbar[] = [];
+    spyOn(progressBarHelper, 'ProgressBar')
+        .and.callFake((specs: string, config: {}) => {
+          const fakeProgbar = new FakeProgbar(specs, config);
+          fakeProgbars.push(fakeProgbar);
+          return fakeProgbar;
+        });
+    const consoleMessages: string[] = [];
+    spyOn(progressBarHelper, 'log').and.callFake((message: string) => {
+      consoleMessages.push(message);
+    });
+
+    const epochs = 2;
+    const xDataset = tf.data.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+                         .map(x => tf.tensor2d(x, [1, 2]));
+    const yDataset =
+        tf.data.array([[1], [2], [3], [4]]).map(y => tf.tensor2d(y, [1, 1]));
+    const dataset = tf.data.zip([xDataset, yDataset]).repeat(epochs);
+
+    const model = tf.sequential();
+    model.add(tf.layers.dense({units: 1, inputShape: [2]}));
+    model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+    await model.fitDataset(dataset, {batchesPerEpoch: 4, epochs, verbose: 1});
+
+    expect(consoleMessages.length).toEqual(4);
+    expect(consoleMessages[0]).toEqual('Epoch 1 / 2');
+    expect(consoleMessages[1]).toMatch(/.*ms .*us\/step - loss=.*/);
+    expect(consoleMessages[2]).toEqual('Epoch 2 / 2');
+    expect(consoleMessages[3]).toMatch(/.*ms .*us\/step - loss=.*/);
+  });
+
+  it('Model.fitDataset: verbose = 0 leads to no logging', async () => {
+    const fakeProgbars: FakeProgbar[] = [];
+    spyOn(progressBarHelper, 'ProgressBar')
+        .and.callFake((specs: string, config: {}) => {
+          const fakeProgbar = new FakeProgbar(specs, config);
+          fakeProgbars.push(fakeProgbar);
+          return fakeProgbar;
+        });
+    const consoleMessages: string[] = [];
+    spyOn(progressBarHelper, 'log').and.callFake((message: string) => {
+      consoleMessages.push(message);
+    });
+
+    const xDataset = tf.data.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+                         .map(x => tf.tensor2d(x, [1, 2]));
+    const yDataset =
+        tf.data.array([[1], [2], [3], [4]]).map(y => tf.tensor2d(y, [1, 1]));
+    const dataset = tf.data.zip([xDataset, yDataset]);
+
+    const model = tf.sequential();
+    model.add(tf.layers.dense({units: 1, inputShape: [2]}));
+    model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+    const history = await model.fitDataset(dataset, {epochs: 1, verbose: 0});
+    expect(history.history.loss.length).toEqual(1);
+    expect(consoleMessages.length)
+        .toEqual(0);  // No logging should have happened.
+  });
 });
 
 describe('getDisplayDecimalPlaces', () => {

--- a/src/callbacks_test.ts
+++ b/src/callbacks_test.ts
@@ -198,6 +198,40 @@ describe('progbarLogger', () => {
     expect(consoleMessages[3]).toMatch(/.*ms .*us\/step - loss=.*/);
   });
 
+  fit('Model.fitDataset: batchesPerEpoch unavailable, verbose = 1', async () => {
+    const fakeProgbars: FakeProgbar[] = [];
+    spyOn(progressBarHelper, 'ProgressBar')
+        .and.callFake((specs: string, config: {}) => {
+          const fakeProgbar = new FakeProgbar(specs, config);
+          fakeProgbars.push(fakeProgbar);
+          return fakeProgbar;
+        });
+    const consoleMessages: string[] = [];
+    spyOn(progressBarHelper, 'log').and.callFake((message: string) => {
+      consoleMessages.push(message);
+    });
+
+    const epochs = 2;
+    const xDataset = tf.data.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+                         .map(x => tf.tensor2d(x, [1, 2]));
+    const yDataset =
+        tf.data.array([[1], [2], [3], [4]]).map(y => tf.tensor2d(y, [1, 1]));
+    const dataset = tf.data.zip([xDataset, yDataset]).repeat(epochs);
+
+    const model = tf.sequential();
+    model.add(tf.layers.dense({units: 1, inputShape: [2]}));
+    model.compile({loss: 'meanSquaredError', optimizer: 'sgd'});
+    // `batchesPerEpoch` is not specified. Instead, `fitDataset()` relies on the
+    // `done` field being `true` to terminate the epoch(s).
+    await model.fitDataset(dataset, {epochs, verbose: 1});
+
+    expect(consoleMessages.length).toEqual(4);
+    expect(consoleMessages[0]).toEqual('Epoch 1 / 2');
+    expect(consoleMessages[1]).toMatch(/.*ms .*us\/step - loss=.*/);
+    expect(consoleMessages[2]).toEqual('Epoch 2 / 2');
+    expect(consoleMessages[3]).toMatch(/.*ms .*us\/step - loss=.*/);
+  });
+
   it('Model.fitDataset: verbose = 0 leads to no logging', async () => {
     const fakeProgbars: FakeProgbar[] = [];
     spyOn(progressBarHelper, 'ProgressBar')

--- a/src/callbacks_test.ts
+++ b/src/callbacks_test.ts
@@ -198,7 +198,7 @@ describe('progbarLogger', () => {
     expect(consoleMessages[3]).toMatch(/.*ms .*us\/step - loss=.*/);
   });
 
-  fit('Model.fitDataset: batchesPerEpoch unavailable, verbose = 1', async () => {
+  it('Model.fitDataset: batchesPerEpoch unavailable, verbose = 1', async () => {
     const fakeProgbars: FakeProgbar[] = [];
     spyOn(progressBarHelper, 'ProgressBar')
         .and.callFake((specs: string, config: {}) => {


### PR DESCRIPTION
- When `batchesPerEpoch` is specified for a `fitDataset()` call, use it as the length of the progress bar.
- In cases where `batchesPerEpoch` is not specified and `fitDataset()` uses `done: true` to terminate epochs, the progress bar will be omitted, and only the loss and metric values will be updated in the CLI during training.

Towards fixing https://github.com/tensorflow/tfjs/issues/1101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/194)
<!-- Reviewable:end -->
