### PR TITLE
Remove usage of tensor.get()

### DIFF
--- a/src/nodejs_kernel_backend_test.ts
+++ b/src/nodejs_kernel_backend_test.ts
@@ -34,9 +34,9 @@ describe('delayed upload', () => {
     const logits = tf.tensor1d([1, 2, 3]);
     const softmaxLogits = tf.softmax(logits);
     const data = softmaxLogits.dataSync();
-    expect(softmaxLogits.get(0)).toEqual(data[0]);
-    expect(softmaxLogits.get(1)).toEqual(data[1]);
-    expect(softmaxLogits.get(2)).toEqual(data[2]);
+    expect(softmaxLogits.dataSync()[0]).toEqual(data[0]);
+    expect(softmaxLogits.dataSync()[1]).toEqual(data[1]);
+    expect(softmaxLogits.dataSync()[2]).toEqual(data[2]);
   });
 });
 


### PR DESCRIPTION
Now that tensor.get() is removed in core: [tensorflow/tfjs-core#1537](https://github.com/tensorflow/tfjs-core/pull/1537), replace it with dataSync()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/200)
<!-- Reviewable:end -->
