### PR TITLE
Replace tf.fromPixels with tf.browser.fromPixels

### DIFF
--- a/src/canvas_test.ts
+++ b/src/canvas_test.ts
@@ -34,11 +34,11 @@ class MockCanvas {
   }
 }
 
-describe('tf.fromPixels', () => {
+describe('tf.browser.fromPixels with polyfills', () => {
   it('accepts a canvas-like element', () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
-    const t = tf.fromPixels(c as any);
+    const t = tf.browser.fromPixels(c as any);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 3]);
     tf.test_util.expectArraysEqual(
@@ -48,7 +48,7 @@ describe('tf.fromPixels', () => {
   it('accepts a canvas-like element, numChannels=4', () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
-    const t = tf.fromPixels(c as any, 4);
+    const t = tf.browser.fromPixels(c as any, 4);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 4]);
     tf.test_util.expectArraysEqual(
@@ -58,7 +58,7 @@ describe('tf.fromPixels', () => {
   it('errors when passed a non-canvas object', () => {
     const c = 5;
     // tslint:disable-next-line:no-any
-    expect(() => tf.fromPixels(c as any))
+    expect(() => tf.browser.fromPixels(c as any))
         .toThrowError(
             /When running in node, pixels must be an HTMLCanvasElement/);
   });

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -1463,7 +1463,7 @@ export class NodeJSKernelBackend extends KernelBackend {
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {
     if (pixels == null) {
-      throw new Error('pixels passed to tf.fromPixels() can not be null');
+      throw new Error('pixels passed to fromPixels() can not be null');
     }
     // tslint:disable-next-line:no-any
     if ((pixels as any).getContext == null) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "noImplicitAny": true,
     "sourceMap": true,
-    "removeComments": true,
+    "removeComments": false,
     "preserveConstEnums": true,
     "declaration": true,
     "target": "es5",


### PR DESCRIPTION
Replace tf.fromPixels with tf.browser.fromPixels.

tf.browser.fromPixels() works with the latest 0.15.1. Will wait until https://github.com/tensorflow/tfjs-node/pull/198 gets in, since it needs 0.15.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/201)
<!-- Reviewable:end -->
