### PR TITLE
Update node engine to `>=8.10.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/tensorflow/tfjs-node.git"
   },
   "engines": {
-    "node": ">=8.11.0"
+    "node": ">=8.10.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Hi!

Thanks for the amazing work with tensorflow-js 🙂

I'm trying to use `@tensorflowjs/tfjs-node` with AWS Lambda but the `engine` field in package.json is conflicting. AWS Lambda is running on node `8.10.0`.

I'm creating this PR to update the node engine to `>=8.10.0`. I think it would make sense because this package does not depend on any of the updates in [the changelog from 8.10.0 to 8.11.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#2018-03-28-version-8110-carbon-lts-mylesborins) and many people can't really choose their node engine.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/207)
<!-- Reviewable:end -->
