### PR TITLE
Shorten the cpp include path

### DIFF
--- a/binding/tf_auto_status.h
+++ b/binding/tf_auto_status.h
@@ -18,7 +18,7 @@
 #ifndef TF_NODEJS_TF_AUTO_STATUS_H_
 #define TF_NODEJS_TF_AUTO_STATUS_H_
 
-#include "../deps/include/tensorflow/c/c_api.h"
+#include "tensorflow/c/c_api.h"
 
 namespace tfnodejs {
 

--- a/binding/tf_auto_tensor.h
+++ b/binding/tf_auto_tensor.h
@@ -18,7 +18,7 @@
 #ifndef TF_NODEJS_TF_AUTO_TENSOR_H_
 #define TF_NODEJS_TF_AUTO_TENSOR_H_
 
-#include "../deps/include/tensorflow/c/c_api.h"
+#include "tensorflow/c/c_api.h"
 
 namespace tfnodejs {
 

--- a/binding/tfe_auto_op.h
+++ b/binding/tfe_auto_op.h
@@ -18,7 +18,7 @@
 #ifndef TF_NODEJS_TFE_AUTO_OP_H_
 #define TF_NODEJS_TFE_AUTO_OP_H_
 
-#include "../deps/include/tensorflow/c/eager/c_api.h"
+#include "tensorflow/c/eager/c_api.h"
 
 namespace tfnodejs {
 

--- a/binding/tfjs_backend.h
+++ b/binding/tfjs_backend.h
@@ -22,7 +22,7 @@
 #include <map>
 #include <memory>
 #include <string>
-#include "../deps/include/tensorflow/c/eager/c_api.h"
+#include "tensorflow/c/eager/c_api.h"
 
 namespace tfnodejs {
 

--- a/binding/utils.h
+++ b/binding/utils.h
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <cstdlib>
 #include <vector>
-#include "../deps/include/tensorflow/c/c_api.h"
+#include "tensorflow/c/c_api.h"
 #include "tf_auto_status.h"
 
 #define MAX_TENSOR_SHAPE 4


### PR DESCRIPTION
In binding.gyp, `<(module_root_dir)/deps/include>`
is used and related settings are also in c_cpp_properties.json.
In the source code, it would be good to use the path
starting with `tensorflow`, instead of relative path.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/216)
<!-- Reviewable:end -->
