### PR TITLE
Fix TypeScript build issues and binary staging for 0.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "tsc",
     "build-npm": "./scripts/build-npm.sh",
     "clean-deps": "rm -rf deps",
-    "coverage": "nyc ts-node src/run_tests.ts",
+    "coverage": "nyc ts-node --files src/run_tests.ts",
     "enable-gpu": "node scripts/install.js gpu download && yarn",
     "format": "clang-format -i -style=Google binding/*.cc binding/*.h",
     "install": "node scripts/install.js",
@@ -23,7 +23,7 @@
     "lint": "tslint -p . -t verbose",
     "prep": "cd node_modules/@tensorflow/tfjs-core && yarn && yarn build",
     "publish-local": "yarn prep && yalc push",
-    "test": "ts-node src/run_tests.ts"
+    "test": "ts-node --files src/run_tests.ts"
   },
   "devDependencies": {
     "@types/bindings": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "nyc": "^13.3.0",
     "shelljs": "^0.8.3",
     "tmp": "^0.0.33",
-    "ts-node": "^5.0.1",
-    "tslint": "~5.9.1",
-    "typescript": "~2.9.2",
+    "ts-node": "~7.0.0",
+    "tslint": "~5.11.0",
+    "typescript": "3.3.3333",
     "yalc": "~1.0.0-pre.21"
   },
   "dependencies": {

--- a/scripts/deps-constants.js
+++ b/scripts/deps-constants.js
@@ -20,7 +20,7 @@ const path = require('path');
 const libName =
     os.platform() === 'win32' ? 'tensorflow.dll' : 'libtensorflow.so';
 const frameworkLibName =
-    os.platform() === 'linux' ? 'libtensorflow_framework.so' : '';
+    os.platform() !== 'win32' ? 'libtensorflow_framework.so' : '';
 
 const depsPath = path.join(__dirname, '..', 'deps');
 const depsLibPath = path.join(depsPath, 'lib');

--- a/scripts/deps-stage.js
+++ b/scripts/deps-stage.js
@@ -50,20 +50,16 @@ async function symlinkDepsLib() {
   }
   try {
     await symlink(depsLibTensorFlowPath, destLibPath);
-    if (os.platform() === 'linux') {
-      await symlink(
-          depsLibTensorFlowFrameworkPath,
-          destFrameworkLibPath);
+    if (os.platform() !== 'win32') {
+      await symlink(depsLibTensorFlowFrameworkPath, destFrameworkLibPath);
     }
   } catch (e) {
     console.error(
         `  * Symlink of ${destLibPath} failed, creating a copy on disk.`);
     await copy(depsLibTensorFlowPath, destLibPath);
     // Linux will require this library as well:
-    if (os.platform() === 'linux') {
-      await copy(
-          depsLibTensorFlowFrameworkPath,
-          destFrameworkLibPath);
+    if (os.platform() !== 'win32') {
+      await copy(depsLibTensorFlowFrameworkPath, destFrameworkLibPath);
     }
   }
 }
@@ -73,10 +69,8 @@ async function symlinkDepsLib() {
  */
 async function moveDepsLib() {
   await rename(depsLibTensorFlowPath, destLibPath);
-  if (os.platform() === 'linux') {
-    await rename(
-        depsLibTensorFlowFrameworkPath,
-        destFrameworkLibPath);
+  if (os.platform() !== 'win32') {
+    await rename(depsLibTensorFlowFrameworkPath, destFrameworkLibPath);
   }
 }
 

--- a/scripts/deps-stage.js
+++ b/scripts/deps-stage.js
@@ -57,7 +57,6 @@ async function symlinkDepsLib() {
     console.error(
         `  * Symlink of ${destLibPath} failed, creating a copy on disk.`);
     await copy(depsLibTensorFlowPath, destLibPath);
-    // Linux will require this library as well:
     if (os.platform() !== 'win32') {
       await copy(depsLibTensorFlowFrameworkPath, destFrameworkLibPath);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,3 +64,4 @@ import {ProgbarLogger} from './callbacks';
 tf.registerCallbackConstructor(1, ProgbarLogger);
 
 export * from './node';
+export * from './tfjs_binding';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ import * as nodeVersion from './version';
 
 // tslint:disable-next-line:no-require-imports
 import bindings = require('bindings');
-import {TFJSBinding} from './tfjs_binding';
 
 // Merge version and io namespaces.
 export const version = {
@@ -45,7 +44,7 @@ const pjson = require('../package.json');
 
 tf.ENV.registerBackend('tensorflow', () => {
   return new NodeJSKernelBackend(
-      bindings('tfjs_binding.node') as TFJSBinding, pjson.name);
+      bindings('tfjs_binding.node') as TensorFlow.TFJSBinding, pjson.name);
 }, 3 /* priority */);
 
 // If registration succeeded, set the backend.
@@ -64,4 +63,3 @@ import {ProgbarLogger} from './callbacks';
 tf.registerCallbackConstructor(1, ProgbarLogger);
 
 export * from './node';
-export * from './tfjs_binding';

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -26,7 +26,6 @@ import {isNullOrUndefined} from 'util';
 import {Int64Scalar} from './int64_tensors';
 // tslint:disable-next-line:max-line-length
 import {createTensorsTypeOpAttr, createTypeOpAttr, getTFDType} from './ops/op_utils';
-import {TensorMetadata, TFEOpAttr, TFJSBinding} from './tfjs_binding';
 
 type TensorInfo = {
   shape: number[],
@@ -38,11 +37,11 @@ type TensorInfo = {
 interface DataId {}
 
 export class NodeJSKernelBackend extends KernelBackend {
-  binding: TFJSBinding;
+  binding: TensorFlow.TFJSBinding;
   isGPUPackage: boolean;
   private tensorMap = new WeakMap<DataId, TensorInfo>();
 
-  constructor(binding: TFJSBinding, packageName: string) {
+  constructor(binding: TensorFlow.TFJSBinding, packageName: string) {
     super();
     this.binding = binding;
     this.isGPUPackage = packageName === '@tensorflow/tfjs-node-gpu';
@@ -70,7 +69,7 @@ export class NodeJSKernelBackend extends KernelBackend {
   }
 
   // Creates a new Tensor and maps the dataId to the passed in ID.
-  private createOutputTensor(metadata: TensorMetadata): Tensor {
+  private createOutputTensor(metadata: TensorFlow.TensorMetadata): Tensor {
     const newId = {};
 
     this.tensorMap.set(newId, {
@@ -137,7 +136,7 @@ export class NodeJSKernelBackend extends KernelBackend {
     return ids;
   }
 
-  private createReductionOpAttrs(tensor: Tensor): TFEOpAttr[] {
+  private createReductionOpAttrs(tensor: Tensor): TensorFlow.TFEOpAttr[] {
     return [
       {name: 'keep_dims', type: this.binding.TF_ATTR_BOOL, value: false},
       createTypeOpAttr('T', tensor.dtype), createTypeOpAttr('Tidx', 'int32')
@@ -160,8 +159,8 @@ export class NodeJSKernelBackend extends KernelBackend {
    * @param inputs The list of input Tensors for the Op.
    * @return A resulting Tensor from Op execution.
    */
-  executeSingleOutput(name: string, opAttrs: TFEOpAttr[], inputs: Tensor[]):
-      Tensor {
+  executeSingleOutput(
+      name: string, opAttrs: TensorFlow.TFEOpAttr[], inputs: Tensor[]): Tensor {
     const outputMetadata = this.binding.executeOp(
         name, opAttrs, this.getInputTensorIds(inputs), 1);
     return this.createOutputTensor(outputMetadata[0]);
@@ -176,7 +175,7 @@ export class NodeJSKernelBackend extends KernelBackend {
    * @return A resulting Tensor array from Op execution.
    */
   executeMultipleOutputs(
-      name: string, opAttrs: TFEOpAttr[], inputs: Tensor[],
+      name: string, opAttrs: TensorFlow.TFEOpAttr[], inputs: Tensor[],
       numOutputs: number): Tensor[] {
     const outputMetadata = this.binding.executeOp(
         name, opAttrs, this.getInputTensorIds(inputs), numOutputs);
@@ -1569,7 +1568,7 @@ export class NodeJSKernelBackend extends KernelBackend {
         inputArgs.push(value);
         typeAttr = this.typeAttributeFromTensor(value);
       }
-      const opAttrs: TFEOpAttr[] =
+      const opAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: this.binding.TF_ATTR_TYPE, value: typeAttr}];
 
       this.binding.executeOp(

--- a/src/ops/op_utils.ts
+++ b/src/ops/op_utils.ts
@@ -19,7 +19,6 @@ import * as tfc from '@tensorflow/tfjs-core';
 import {isArray, isNullOrUndefined} from 'util';
 
 import {NodeJSKernelBackend} from '../nodejs_kernel_backend';
-import {TFEOpAttr} from '../tfjs_binding';
 
 let gBackend: NodeJSKernelBackend = null;
 
@@ -63,7 +62,7 @@ export function getTFDType(dataType: tfc.DataType): number {
  * @deprecated Please use createTensorsTypeOpAttr() going forward.
  */
 export function createTypeOpAttr(
-    attrName: string, dtype: tfc.DataType): TFEOpAttr {
+    attrName: string, dtype: tfc.DataType): TensorFlow.TFEOpAttr {
   return {
     name: attrName,
     type: nodeBackend().binding.TF_ATTR_TYPE,

--- a/src/tfjs_binding.d.ts
+++ b/src/tfjs_binding.d.ts
@@ -15,55 +15,57 @@
  * =============================================================================
  */
 
-declare class TensorMetadata {
-  id: number;
-  shape: number[];
-  dtype: number;
-}
+declare namespace TensorFlow {
+  class TensorMetadata {
+    id: number;
+    shape: number[];
+    dtype: number;
+  }
 
-declare class TFEOpAttr {
-  name: string;
-  type: number;
-  value: boolean|number|object|string|number[];
-}
+  class TFEOpAttr {
+    name: string;
+    type: number;
+    value: boolean|number|object|string|number[];
+  }
 
-export interface TFJSBinding {
-  TensorMetadata: typeof TensorMetadata;
-  TFEOpAttr: typeof TFEOpAttr;
+  interface TFJSBinding {
+    TensorMetadata: typeof TensorMetadata;
+    TFEOpAttr: typeof TFEOpAttr;
 
-  // Creates a tensor with the backend:
-  createTensor(
-      shape: number[], dtype: number,
-      buffer: Float32Array|Int32Array|Uint8Array): number;
+    // Creates a tensor with the backend:
+    createTensor(
+        shape: number[], dtype: number,
+        buffer: Float32Array|Int32Array|Uint8Array): number;
 
-  // Deletes a tensor with the backend:
-  deleteTensor(tensorId: number): void;
+    // Deletes a tensor with the backend:
+    deleteTensor(tensorId: number): void;
 
-  // Reads data-sync from a tensor on the backend:
-  tensorDataSync(tensorId: number): Float32Array|Int32Array|Uint8Array;
+    // Reads data-sync from a tensor on the backend:
+    tensorDataSync(tensorId: number): Float32Array|Int32Array|Uint8Array;
 
-  // Executes an Op on the backend, returns an array of output TensorMetadata:
-  executeOp(
-      opName: string, opAttrs: TFEOpAttr[], inputTensorIds: number[],
-      numOutputs: number): TensorMetadata[];
+    // Executes an Op on the backend, returns an array of output TensorMetadata:
+    executeOp(
+        opName: string, opAttrs: TFEOpAttr[], inputTensorIds: number[],
+        numOutputs: number): TensorMetadata[];
 
-  // TF Types
-  TF_FLOAT: number;
-  TF_INT32: number;
-  TF_INT64: number;
-  TF_BOOL: number;
-  TF_COMPLEX64: number;
-  TF_STRING: number;
-  TF_RESOURCE: number;
+    // TF Types
+    TF_FLOAT: number;
+    TF_INT32: number;
+    TF_INT64: number;
+    TF_BOOL: number;
+    TF_COMPLEX64: number;
+    TF_STRING: number;
+    TF_RESOURCE: number;
 
-  // TF OpAttrTypes
-  TF_ATTR_STRING: number;
-  TF_ATTR_INT: number;
-  TF_ATTR_FLOAT: number;
-  TF_ATTR_BOOL: number;
-  TF_ATTR_TYPE: number;
-  TF_ATTR_SHAPE: number;
-  TF_ATTR_RESOURCE: number;
+    // TF OpAttrTypes
+    TF_ATTR_STRING: number;
+    TF_ATTR_INT: number;
+    TF_ATTR_FLOAT: number;
+    TF_ATTR_BOOL: number;
+    TF_ATTR_TYPE: number;
+    TF_ATTR_SHAPE: number;
+    TF_ATTR_RESOURCE: number;
 
-  TF_Version: string;
+    TF_Version: string;
+  }
 }

--- a/src/tfjs_binding.d.ts
+++ b/src/tfjs_binding.d.ts
@@ -15,13 +15,13 @@
  * =============================================================================
  */
 
-export class TensorMetadata {
+declare class TensorMetadata {
   id: number;
   shape: number[];
   dtype: number;
 }
 
-export class TFEOpAttr {
+declare class TFEOpAttr {
   name: string;
   type: number;
   value: boolean|number|object|string|number[];

--- a/src/tfjs_binding.ts
+++ b/src/tfjs_binding.ts
@@ -15,13 +15,13 @@
  * =============================================================================
  */
 
-declare class TensorMetadata {
+export class TensorMetadata {
   id: number;
   shape: number[];
   dtype: number;
 }
 
-declare class TFEOpAttr {
+export class TFEOpAttr {
   name: string;
   type: number;
   value: boolean|number|object|string|number[];

--- a/src/tfjs_binding_test.ts
+++ b/src/tfjs_binding_test.ts
@@ -17,8 +17,7 @@
 
 // tslint:disable-next-line:no-require-imports
 import bindings = require('bindings');
-import {TFJSBinding, TFEOpAttr} from './tfjs_binding';
-const binding = bindings('tfjs_binding.node') as TFJSBinding;
+const binding = bindings('tfjs_binding.node') as TensorFlow.TFJSBinding;
 
 describe('Exposes TF_DataType enum values', () => {
   it('contains TF_FLOAT', () => {
@@ -128,7 +127,8 @@ describe('executeOp', () => {
 
   it('throws exception with invalid Op Name', () => {
     expect(() => {
-      binding.executeOp(null, [] as TFEOpAttr[], [] as number[], null);
+      binding.executeOp(
+          null, [] as TensorFlow.TFEOpAttr[], [] as number[], null);
     }).toThrowError();
   });
   it('throws exception with invalid TFEOpAttr', () => {
@@ -148,147 +148,147 @@ describe('executeOp', () => {
   });
   it('throws exception with invalid TF_ATTR_STRING op attr', () => {
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_STRING, value: null}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_STRING, value: false}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_STRING, value: 1}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_STRING, value: new Object()}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_STRING, value: [1, 2, 3]}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
   });
   it('throws exception with invalid TF_ATTR_INT op attr', () => {
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_INT, value: null}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_INT, value: false}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_INT, value: new Object()}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_INT, value: 'test'}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_INT, value: [1, 2, 3]}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
   });
   it('throws exception with invalid TF_ATTR_FLOAT op attr', () => {
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_FLOAT, value: null}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_FLOAT, value: false}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_FLOAT, value: new Object()}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_FLOAT, value: 'test'}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_FLOAT, value: [1, 2, 3]}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
   });
   it('throws exception with invalid TF_ATTR_BOOL op attr', () => {
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_BOOL, value: null}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_BOOL, value: 10}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_BOOL, value: new Object()}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_BOOL, value: 'test'}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_BOOL, value: [1, 2, 3]}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
   });
   it('throws exception with invalid TF_ATTR_TYPE op attr', () => {
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_TYPE, value: null}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_TYPE, value: new Object()}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_TYPE, value: 'test'}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_TYPE, value: [1, 2, 3]}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
   });
   it('throws exception with invalid TF_ATTR_SHAPE op attr', () => {
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_TYPE, value: null}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_TYPE, value: new Object()}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();
     expect(() => {
-      const badOpAttrs: TFEOpAttr[] =
+      const badOpAttrs: TensorFlow.TFEOpAttr[] =
           [{name: 'T', type: binding.TF_ATTR_TYPE, value: 'test'}];
       binding.executeOp(name, badOpAttrs, matMulInput, 1);
     }).toThrowError();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
     "preserveConstEnums": true,
     "declaration": true,
     "target": "es5",
-    "lib": ["es2015", "dom"],
+    "lib": [
+      "es2015",
+      "dom"
+    ],
     "outDir": "./dist",
     "noUnusedLocals": true,
     "noImplicitReturns": true,
@@ -21,5 +24,5 @@
   },
   "include": [
     "src/"
-  ]
+  ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "noImplicitAny": true,
     "sourceMap": true,
+    "baseUrl": ".",
     "removeComments": false,
     "preserveConstEnums": true,
     "declaration": true,
@@ -20,9 +21,18 @@
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
     "allowUnreachableCode": false,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "paths": {
+      "*": [
+        "*",
+        "src/*"
+      ]
+    },
   },
   "include": [
     "src/"
   ],
+  "files": [
+    "src/tfjs_binding.d.ts"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,7 +380,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-buffer-from@^1.0.0:
+buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -1665,10 +1665,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-source-map-support@^0.5.3:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
-  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
+source-map-support@^0.5.6:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
+  integrity sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -1833,18 +1833,18 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-node@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-5.0.1.tgz#78e5d1cb3f704de1b641e43b76be2d4094f06f81"
-  integrity sha512-XK7QmDcNHVmZkVtkiwNDWiERRHPyU8nBqZB1+iv2UhOG0q3RQ9HsZ2CMqISlFbxjrYFGfG2mX7bW4dAyxBVzUw==
+ts-node@~7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
+  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
   dependencies:
     arrify "^1.0.0"
-    chalk "^2.3.0"
+    buffer-from "^1.1.0"
     diff "^3.1.0"
     make-error "^1.1.1"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    source-map-support "^0.5.3"
+    source-map-support "^0.5.6"
     yn "^2.0.0"
 
 tslib@^1.8.0, tslib@^1.8.1:
@@ -1852,10 +1852,10 @@ tslib@^1.8.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint@~5.9.1:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
-  integrity sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
+tslint@~5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
+  integrity sha1-mPMMAurjzecAYgHkwzywi0hYHu0=
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -1868,19 +1868,19 @@ tslint@~5.9.1:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.12.1"
+    tsutils "^2.27.2"
 
-tsutils@^2.12.1:
+tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   dependencies:
     tslib "^1.8.1"
 
-typescript@~2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@3.3.3333:
+  version "3.3.3333"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
+  integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
This is part of a fix for https://github.com/tensorflow/tfjs/issues/1092

I also noticed that binary placement had regressed on Mac OS installs - the published NPM script seems to symlink instead of move (probably due to failure). MacOS and Linux binaries from TF need both libtensorflow.so and tensorflow_framework.so.

I had to re-work binding loading to specifically use a Namespace and load a definition. This involves changes to the tsconfig.json. I'll update `node-gles` as well with this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/222)
<!-- Reviewable:end -->
