### PR TITLE
Share host memory of Tensors with V8.

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -7,7 +7,7 @@
         "${workspaceFolder}/deps/include",
         "${workspaceFolder}/deps/tensorflow/include/tensorflow/c",
         "${workspaceFolder}/deps/tensorflow/include/tensorflow/c/eager",
-        "${env.HOME}/.node-gyp/10.3.0/include/node"
+        "${env.HOME}/.node-gyp/10.15.3/include/node"
       ],
       "defines": [],
       "intelliSenseMode": "clang-x64",
@@ -17,7 +17,7 @@
           "${workspaceFolder}/deps/include",
           "${workspaceFolder}/deps/tensorflow/include/tensorflow/c",
           "${workspaceFolder}/deps/tensorflow/include/tensorflow/c/eager",
-          "${env.HOME}/.node-gyp/10.3.0/include/node"
+          "${env.HOME}/.node-gyp/10.15.3/include/node"
         ],
         "limitSymbolsToIncludedHeaders": true,
         "databaseFilename": ""

--- a/binding/napi_auto_ref.h
+++ b/binding/napi_auto_ref.h
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+#ifndef TF_NODEJS_NAPI_AUTO_REF_H_
+#define TF_NODEJS_NAPI_AUTO_REF_H_
+
+#include <node_api.h>
+#include "utils.h"
+
+namespace tfnodejs {
+
+// Helper class to automatically cleanup napi_ref instances.
+class NapiAutoRef {
+ public:
+  NapiAutoRef() : env_(nullptr), ref_(nullptr) {}
+
+  napi_status Init(napi_env env, napi_value value) {
+    env_ = env;
+    return napi_create_reference(env_, value, 1, &ref_);
+  }
+
+  napi_status Cleanup() {
+    if (!env_ || !ref_) {
+#if DEBUG
+      NAPI_THROW_ERROR(env_, "Uninitialized reference attempted to cleanup");
+#endif
+      return napi_invalid_arg;
+    }
+
+    napi_status nstatus = napi_delete_reference(env_, ref_);
+    env_ = nullptr;
+    ref_ = nullptr;
+    return nstatus;
+  }
+
+  virtual ~NapiAutoRef() {
+    if (env_) {
+#if DEBUG
+      NAPI_THROW_ERROR(env_, "Non-cleaned up napi_env instance");
+#endif
+    }
+    if (ref_) {
+#if DEBUG
+      NAPI_THROW_ERROR(env_, "Non-cleaned up napi_ref instance");
+#endif
+    }
+  }
+
+ private:
+  napi_env env_;
+  napi_ref ref_;
+};
+
+}  // namespace tfnodejs
+
+#endif  // TF_NODEJS_NAPI_AUTO_REF_H_


### PR DESCRIPTION
This PR introduces a new change to use V8 memory for Tensor memory allocation.

Previously, Tensor data was allocated off of the heap and `memcpy`'d from host V8 memory to the allocated Tensor data. Since the TF C API provides a callback when `TF_Tensor` instances are cleaned up, we can share host memory with V8 by simple adding and additional reference count to the represented JS typed-array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/241)
<!-- Reviewable:end -->
