### PR TITLE
Update tfjs dependency to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "yalc": "~1.0.0-pre.21"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "~1.1.0",
+    "@tensorflow/tfjs": "~1.1.2",
     "adm-zip": "^0.4.11",
     "bindings": "~1.3.0",
     "https-proxy-agent": "^2.2.1",

--- a/src/canvas_test.ts
+++ b/src/canvas_test.ts
@@ -35,24 +35,25 @@ class MockCanvas {
 }
 
 describe('tf.browser.fromPixels with polyfills', () => {
-  it('accepts a canvas-like element', () => {
+  it('accepts a canvas-like element', async () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
     const t = tf.browser.fromPixels(c as any);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 3]);
     tf.test_util.expectArraysEqual(
-        t, [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
+        await t.data(), [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]);
   });
 
-  it('accepts a canvas-like element, numChannels=4', () => {
+  it('accepts a canvas-like element, numChannels=4', async () => {
     const c = new MockCanvas(2, 2);
     // tslint:disable-next-line:no-any
     const t = tf.browser.fromPixels(c as any, 4);
     expect(t.dtype).toBe('int32');
     expect(t.shape).toEqual([2, 2, 4]);
     tf.test_util.expectArraysEqual(
-        t, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+        await t.data(),
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
   });
 
   it('errors when passed a non-canvas object', () => {

--- a/src/index_test.ts
+++ b/src/index_test.ts
@@ -18,10 +18,10 @@
 import * as tf from './index';
 
 describe('Ops are exported from index and work', () => {
-  it('tf.mul works', () => {
+  it('tf.mul works', async () => {
     const a = tf.tensor1d([1, 2, 3]);
     const b = tf.tensor1d([3, 4, 5]);
-    tf.test_util.expectArraysClose(a.mul(b), [3, 8, 15]);
+    tf.test_util.expectArraysClose(await a.mul(b).data(), [3, 8, 15]);
   });
 });
 

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -1543,6 +1543,15 @@ export class NodeJSKernelBackend extends KernelBackend {
     ]) as Tensor<R>;
   }
 
+  linspace(start: number, stop: number, num: number): Tensor1D {
+    const opAttrs =
+        [createTypeOpAttr('T', 'float32'), createTypeOpAttr('Tidx', 'int32')];
+    const inputs = [
+      scalar(start, 'float32'), scalar(stop, 'float32'), scalar(num, 'int32')
+    ];
+    return this.executeSingleOutput('LinSpace', opAttrs, inputs) as Tensor1D;
+  }
+
   fromPixels(
       pixels: ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement,
       numChannels: number): Tensor3D {

--- a/src/nodejs_kernel_backend_test.ts
+++ b/src/nodejs_kernel_backend_test.ts
@@ -22,12 +22,12 @@ import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
 import {NodeJSKernelBackend} from './nodejs_kernel_backend';
 
 describe('delayed upload', () => {
-  it('should handle data before op execution', () => {
+  it('should handle data before op execution', async () => {
     const t = tf.tensor1d([1, 2, 3]);
-    expectArraysClose(t, [1, 2, 3]);
+    expectArraysClose(await t.data(), [1, 2, 3]);
 
     const r = t.add(tf.tensor1d([4, 5, 6]));
-    expectArraysClose(r, [5, 7, 9]);
+    expectArraysClose(await r.data(), [5, 7, 9]);
   });
 
   it('Should not cache tensors in the tensor map for device support. ', () => {
@@ -51,7 +51,7 @@ describe('conv3d dilations', () => {
     const input = tf.ones([1, 2, 2, 2, 1]) as Tensor5D;
     const filter = tf.ones([1, 1, 1, 1, 1]) as Tensor5D;
     expect(() => {
-      tf.conv3d(input, filter, 1, 'same', 'NHWC', [2, 2, 2]);
+      tf.conv3d(input, filter, 1, 'same', 'NDHWC', [2, 2, 2]);
     }).toThrowError();
   });
   it('GPU should handle dilations >1', () => {
@@ -60,7 +60,7 @@ describe('conv3d dilations', () => {
     if ((tf.backend() as NodeJSKernelBackend).isGPUPackage) {
       const input = tf.ones([1, 2, 2, 2, 1]) as Tensor5D;
       const filter = tf.ones([1, 1, 1, 1, 1]) as Tensor5D;
-      tf.conv3d(input, filter, 1, 'same', 'NHWC', [2, 2, 2]);
+      tf.conv3d(input, filter, 1, 'same', 'NDHWC', [2, 2, 2]);
     }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,15 +90,15 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@tensorflow/tfjs-converter@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.1.0.tgz#1d6f58347e9b3826c02090e06e6590b0c4df2d4e"
-  integrity sha512-gUkoRoYm9yrVVQNp8nD+pEWOPUNhayCSrUHNItSfIm8Lzbgx6brVxVdz5T8V0kT0yh67Pp9Er/LIlf54p7KikA==
+"@tensorflow/tfjs-converter@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.1.2.tgz#2400ac77b30f973f1fcb26c912b28271f7f4d605"
+  integrity sha512-KuLIIJYzmRmtJXcjBH3inQVhTHbABj2TNAVS3ss12hzDiEE/RiRb/LZKo8XV2WczuZXTq+gxep84PWXSH/HQXA==
 
-"@tensorflow/tfjs-core@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.0.tgz#028c69291e19c328c4c30e18d29b09135c22cb44"
-  integrity sha512-loPpHGVjiyEb+Ixlsj8prQ/r4exekITn7vM4WEyHUouFKx0/CuoB2FQ0m6DSb/6ApvucxTWGGNTRRo4HK4Ma0Q==
+"@tensorflow/tfjs-core@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.2.tgz#efb8b3688fbff353e51d41a3d832dde8c1bc321d"
+  integrity sha512-xCAUIAh14OFnHt+IQUUZIH/P/jH/EWvewL0Ty6q6USUx4YZ+HvKwNw1G7h/gKki4A31BJ0avD04ylBKc75laGg==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
@@ -108,28 +108,28 @@
   optionalDependencies:
     rollup-plugin-visualizer "~1.1.1"
 
-"@tensorflow/tfjs-data@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.1.0.tgz#8d9a0175497930061532c8d43b419b25b26b9bbf"
-  integrity sha512-0+PfAsaZs/pmaxiLunb4c1rPRdu47+CYe5kxpu2P8Xn3k+vhlBYMu+zsVgs5RrTRFLWVzVeH9muA1SJLkMGZPA==
+"@tensorflow/tfjs-data@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.1.2.tgz#f37809aa89946a834f3566bd090db852f2c4244e"
+  integrity sha512-K30QdocXd5zn3rpGbRTC4sO42q8tK1SGqDHE2IEkvYzcg0PAU3cEMODGTLjKt0z1Lfy1JKgs0FPcvazqmxpjGA==
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
 
-"@tensorflow/tfjs-layers@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.1.0.tgz#fd221c254d2fca13e93e83669bdde3140e7a0434"
-  integrity sha512-a0gXjOWvGi9gc2q8/gK79zfD5WqEZnAhZfpm6b7AoKXjDUBq4GgdbbWCfv2nYBlmMoXgRSRSV44UmJVExep0uw==
+"@tensorflow/tfjs-layers@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.1.2.tgz#29393221446a877962b71084305597295504801e"
+  integrity sha512-iP9mJz/79nK+sXBWdxQkeNIqn9p+O/x3g15ntIXpEaLXOGjQEE12iKtLCWgG3qH+FltOVt5hTbAXkj/yDym1Xg==
 
-"@tensorflow/tfjs@~1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.1.0.tgz#77809dc336655a7ff0bbf76527cc3d7b9e68e330"
-  integrity sha512-CxcFzl2KtknO3f12xuuv8kq8usMA7xGWpJajubIlYBp4KoBDhiDimP/DwBlTvFZq5RT5riHGtA4BWjMj6rnDcw==
+"@tensorflow/tfjs@~1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.1.2.tgz#9a1c2bbc4d82f9d18f250ab4a4d7c8ad43e2d432"
+  integrity sha512-b+ekLNEfMzaBszti6uGcS3pJoPNQuv1hxKEoY9Q3ix52fFJzI86nSvM1lwOcvUZy6DjPFDoyB8MO+dJHqecG5w==
   dependencies:
-    "@tensorflow/tfjs-converter" "1.1.0"
-    "@tensorflow/tfjs-core" "1.1.0"
-    "@tensorflow/tfjs-data" "1.1.0"
-    "@tensorflow/tfjs-layers" "1.1.0"
+    "@tensorflow/tfjs-converter" "1.1.2"
+    "@tensorflow/tfjs-core" "1.1.2"
+    "@tensorflow/tfjs-data" "1.1.2"
+    "@tensorflow/tfjs-layers" "1.1.2"
 
 "@types/bindings@~1.3.0":
   version "1.3.0"


### PR DESCRIPTION
Now that tfjs 1.1.2 is released update the dependency in tfjs-node and fix all build/test issues.

- Implement `LinSpace` kernel
- Fix build errors introduced by change in the signature of `expectArraysEqual/Close` where `Tensor` is not a valid entry anymore, and we want to avoid calling `dataSync() ` in unit tests so we can run unit tests against async-only backends

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/246)
<!-- Reviewable:end -->
