### PR TITLE
Increase allowed heap to fix stack overflow

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -127,7 +127,7 @@
               ],
               'action': [
                 'cmd',
-                '/c node <@(_inputs) > <@(_outputs)'
+                '/c node --max-old-space-size=3096 <@(_inputs) > <@(_outputs)'
               ]
             },
             {

--- a/binding.gyp
+++ b/binding.gyp
@@ -127,7 +127,7 @@
               ],
               'action': [
                 'cmd',
-                '/c node --max-old-space-size=3096 <@(_inputs) > <@(_outputs)'
+                '/c node --max-old-space-size=4096 <@(_inputs) > <@(_outputs)'
               ]
             },
             {


### PR DESCRIPTION
The current windows tensorflow.dll is 769M;  Node by default has a 1.5GB.  The build is doing a join() of all input things in an array, so there is 1 copy and a new copy in the new buffer that is 769M + Other files; this is more than 1.5GB.  I tried setting just --max-old-size=2048 and it still overflowed... I didn't spend a lot of time trying to tune a minimum boundary.
I ran into this issue installing tfjs-node-gpu, which I assume is something of a fork of this for publishing?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/251)
<!-- Reviewable:end -->
