### PR TITLE
Use relative path to link to tf shared libs

### DIFF
--- a/scripts/deps-stage.js
+++ b/scripts/deps-stage.js
@@ -49,9 +49,15 @@ async function symlinkDepsLib() {
     throw new Error('Destination path not supplied!');
   }
   try {
-    await symlink(depsLibTensorFlowPath, destLibPath);
+    await symlink(
+        path.relative(path.dirname(destLibPath), depsLibTensorFlowPath),
+        destLibPath);
     if (os.platform() !== 'win32') {
-      await symlink(depsLibTensorFlowFrameworkPath, destFrameworkLibPath);
+      await symlink(
+          path.relative(
+              path.dirname(destFrameworkLibPath),
+              depsLibTensorFlowFrameworkPath),
+          destFrameworkLibPath);
     }
   } catch (e) {
     console.error(


### PR DESCRIPTION
When linking the tf shared libs for node binding, the symbolic links may
become invalid if the application folder is moved to different directory.
Using relative path to create the symbolic links may avoid this issue.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/252)
<!-- Reviewable:end -->
