### PR TITLE
EncodeBase64 and DecodeBase64 ops

### DIFF
--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -19,7 +19,7 @@
 import {BackendTimingInfo, DataMover, DataType, fill, KernelBackend, ones, Rank, rsqrt, Scalar, scalar, ShapeMap, Tensor, Tensor1D, tensor1d, Tensor2D, tensor2d, Tensor3D, tensor3d, Tensor4D, tidy, util} from '@tensorflow/tfjs-core';
 import {Conv2DInfo, Conv3DInfo} from '@tensorflow/tfjs-core/dist/ops/conv_util';
 import {Activation} from '@tensorflow/tfjs-core/dist/ops/fused_util';
-import {Tensor5D} from '@tensorflow/tfjs-core/dist/tensor';
+import {StringTensor, Tensor5D} from '@tensorflow/tfjs-core/dist/tensor';
 import {upcastType} from '@tensorflow/tfjs-core/dist/types';
 import {isNullOrUndefined} from 'util';
 
@@ -1550,6 +1550,21 @@ export class NodeJSKernelBackend extends KernelBackend {
       scalar(start, 'float32'), scalar(stop, 'float32'), scalar(num, 'int32')
     ];
     return this.executeSingleOutput('LinSpace', opAttrs, inputs) as Tensor1D;
+  }
+
+  encodeBase64<T extends StringTensor>(str: StringTensor|Tensor, pad = false):
+      T {
+    const opAttrs =
+        [{name: 'pad', type: this.binding.TF_ATTR_BOOL, value: pad}];
+    return this.executeSingleOutput('EncodeBase64', opAttrs, [str as Tensor]) as
+        T;
+  }
+
+  decodeBase64<T extends StringTensor>(str: StringTensor|Tensor): T {
+    // return this.executeSingleInput('DecodeBase64', str as Tensor) as Tensor;
+    const opAttrs: TFEOpAttr[] = [];
+    return this.executeSingleOutput('DecodeBase64', opAttrs, [str as Tensor]) as
+        T;
   }
 
   fromPixels(


### PR DESCRIPTION
the TF implementation of the pix2pix model which fails conversion because of

```
Unsupported Ops: DecodeJpeg, EncodePng, DecodeBase64
```

the Open NSFW model also fails conversion with some of the same ops (https://github.com/tensorflow/tfjs/issues/433).

i wanted to try to implement some of these ops in TensorFlow.js. starting with this pull request for `DecodeBase64` and `EncodeBase64`.

along with this `tfjs-node` PR, there are corresponding PRs in `tfjs-core` (https://github.com/tensorflow/tfjs-core/pull/1779) and in `tfjs-converter` (https://github.com/tensorflow/tfjs-converter/pull/376)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/259)
<!-- Reviewable:end -->
