### PR TITLE
Don't use xargs in npm publish because it stomps the OTP.

### DIFF
--- a/scripts/publish-npm-gpu.sh
+++ b/scripts/publish-npm-gpu.sh
@@ -50,12 +50,8 @@ if [ "$GPU_TARBALL_COUNT" != "1" ]; then
   exit
 fi
 
-#echo "Enter OTP: "
-#read otp
-
 # Publish the GPU package
 npm publish $GPU_TARBALLS
-#echo $GPU_TARBALLS | xargs npm publish $GPU_TARBALLS --otp $otp
 
 ./scripts/tag-version
 echo 'Yay! Published the tfjs-node-gpu package to npm.'

--- a/scripts/publish-npm-gpu.sh
+++ b/scripts/publish-npm-gpu.sh
@@ -40,6 +40,7 @@ if ! [[ "$ORIGIN" =~ tensorflow/tfjs-node ]]; then
 fi
 
 ./scripts/make-version # This is for safety in case you forgot to do 2).
+yarn build-npm-gpu
 
 GPU_TARBALLS=$(ls tensorflow-tfjs-node-gpu*.tgz)
 GPU_TARBALL_COUNT=$(echo $GPU_TARBALLS | wc -w | xargs)
@@ -49,8 +50,12 @@ if [ "$GPU_TARBALL_COUNT" != "1" ]; then
   exit
 fi
 
-yarn build-npm-gpu
+#echo "Enter OTP: "
+#read otp
+
 # Publish the GPU package
-echo $GPU_TARBALLS | xargs npm publish
+npm publish $GPU_TARBALLS
+#echo $GPU_TARBALLS | xargs npm publish $GPU_TARBALLS --otp $otp
+
 ./scripts/tag-version
 echo 'Yay! Published the tfjs-node-gpu package to npm.'


### PR DESCRIPTION
Also fixes a bug where we don't build the NPM before publishing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/263)
<!-- Reviewable:end -->
