### PR TITLE
during installation, override TF_VERSION from env variable

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -30,13 +30,15 @@ const rename = util.promisify(fs.rename);
 const rimrafPromise = util.promisify(rimraf);
 const unlink = util.promisify(fs.unlink);
 
+const TF_VERSION = '1.14.0';
+
 const BASE_URI =
     'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
-const CPU_DARWIN = 'cpu-darwin-x86_64-1.14.0.tar.gz';
-const CPU_LINUX = 'cpu-linux-x86_64-1.14.0.tar.gz';
-const GPU_LINUX = 'gpu-linux-x86_64-1.14.0.tar.gz';
-const CPU_WINDOWS = 'cpu-windows-x86_64-1.14.0.zip';
-const GPU_WINDOWS = 'gpu-windows-x86_64-1.14.0.zip';
+const CPU_DARWIN = 'cpu-darwin-x86_64-' + TF_VERSION + '.tar.gz';
+const CPU_LINUX = 'cpu-linux-x86_64-' + TF_VERSION + '.tar.gz';
+const GPU_LINUX = 'gpu-linux-x86_64-' + TF_VERSION + '.tar.gz';
+const CPU_WINDOWS = 'cpu-windows-x86_64-' + TF_VERSION + '.zip';
+const GPU_WINDOWS = 'gpu-windows-x86_64-' + TF_VERSION + '.zip';
 
 // TODO(kreeger): Update to TensorFlow 1.13:
 // https://github.com/tensorflow/tfjs/issues/1369

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -30,7 +30,7 @@ const rename = util.promisify(fs.rename);
 const rimrafPromise = util.promisify(rimraf);
 const unlink = util.promisify(fs.unlink);
 
-const TF_VERSION = '1.14.0';
+const TF_VERSION = process.env['TF_VERSION'] || process.env['tf_version'] || '1.14.0';
 
 const BASE_URI =
     'https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-';
@@ -109,7 +109,7 @@ async function downloadLibtensorflow(callback) {
   // Ensure dependencies staged directory is available:
   await ensureDir(depsPath);
 
-  console.warn('* Downloading libtensorflow');
+  console.warn('* Downloading libtensorflow (' + TF_VERSION + ')');
   resources.downloadAndUnpackResource(
       getPlatformLibtensorflowUri(), depsPath, async () => {
         if (platform === 'win32') {


### PR DESCRIPTION
I'd like to go one step further than https://github.com/tensorflow/tfjs-node/pull/268

Root problem is here https://github.com/tensorflow/tfjs/issues/1660#issuecomment-505802914

I'd like to be able to do 
```
export TF_VERSION=1.12.1
npm install tfjs-node-gpu
```
And use tfjs-node-gpu, at my own risks, using  js code `1.2.1` with `libtensorflow.so-1.12.1`

Thanks for this lib

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/269)
<!-- Reviewable:end -->
