### PR TITLE
Cleanup changed binding.gyp rules and prevent error when running GPU

### DIFF
--- a/scripts/publish-npm-gpu.sh
+++ b/scripts/publish-npm-gpu.sh
@@ -53,5 +53,7 @@ fi
 # Publish the GPU package
 npm publish $GPU_TARBALLS
 
-./scripts/tag-version
+# Cleanup
+git checkout .
+
 echo 'Yay! Published the tfjs-node-gpu package to npm.'


### PR DESCRIPTION
release.

This exception happens because we tag in the CPU tfjs-node release
script.
```
Error: Could not git tag with v1.2.3: Command failed: git tag v1.2.3
fatal: tag 'v1.2.3' already exists
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/272)
<!-- Reviewable:end -->
