### PR TITLE
Fallback to compile addon from source silently when pre-compiled addon is not available

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -175,16 +175,9 @@ async function downloadLibtensorflow(callback) {
  */
 async function build() {
   console.error('* Building TensorFlow Node.js bindings');
-  cp.exec('node-pre-gyp install', (err) => {
+  cp.exec('node-pre-gyp install --fallback-to-build', (err) => {
     if (err) {
-      console.log('node-pre-gyp install failed with: ' + err);
-      console.log('Start building from source binary.');
-      cp.exec('node-pre-gyp install --build-from-source', (error) => {
-        if (error) {
-          console.log('node-pre-gyp install from source failed with error: ' +
-            error);
-        }
-      });
+      console.log('node-pre-gyp install failed with error: ' + err);
     }
     if (platform === 'win32') {
       // Move libtensorflow to module path, where tfjs_binding.node locates.


### PR DESCRIPTION
With pre-compile addon, it's likely that we miss uploading the addon for one or two platforms when publishing npm package. The package could build native addon from source when the addon is not available on GCP, but we should not print out error message which confuses user.

node-pre-gyp provides an option `node-pre-gyp install --fallback-to-build` which silently fallback to compile addon from source when it fails to download from GCP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/278)
<!-- Reviewable:end -->
