### PR TITLE
Upgrade @tensorflow/tfjs to 1.2.3 and handle strings as bytes

### DIFF
--- a/binding/tfjs_backend.cc
+++ b/binding/tfjs_backend.cc
@@ -183,7 +183,7 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromTypedArray(napi_env env,
 }
 
 // Creates a TFE_TensorHandle from a JS array of Uint8Array values.
-TFE_TensorHandle *CreateTFE_TensorHandleFromUtf8StringArray(
+TFE_TensorHandle *CreateTFE_TensorHandleFromStringArray(
     napi_env env, int64_t *shape, uint32_t shape_length, TF_DataType dtype,
     napi_value array_value) {
   napi_status nstatus;
@@ -211,7 +211,7 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromUtf8StringArray(
     // Only Uint8 typed arrays are supported.
     if (array_type != napi_uint8_array) {
       NAPI_THROW_ERROR(env,
-                       "Unsupported array type - expecting Uint8 typed array");
+                       "Unsupported array type - expecting Uint8Array");
       return nullptr;
     }
 
@@ -266,7 +266,7 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromJSValues(napi_env env,
     return CreateTFE_TensorHandleFromTypedArray(env, shape, shape_length, dtype,
                                                 array_value);
   } else {
-    return CreateTFE_TensorHandleFromUtf8StringArray(env, shape, shape_length,
+    return CreateTFE_TensorHandleFromStringArray(env, shape, shape_length,
                                                      dtype, array_value);
   }
 }

--- a/binding/tfjs_backend.cc
+++ b/binding/tfjs_backend.cc
@@ -22,6 +22,8 @@
 #include "tfe_auto_op.h"
 #include "utils.h"
 
+#include <iostream>  // TODO(kreeger): drop this
+
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -183,7 +185,7 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromTypedArray(napi_env env,
 }
 
 // TODO(kreeger): Doc me
-TFE_TensorHandle *CreateTFE_TensorHandleFromStringUtf8StringArray(
+TFE_TensorHandle *CreateTFE_TensorHandleFromUtf8StringArray(
     napi_env env, int64_t *shape, uint32_t shape_length, TF_DataType dtype,
     napi_value array_value) {
   napi_status nstatus;
@@ -201,46 +203,22 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromStringUtf8StringArray(
     ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
     ENSURE_VALUE_IS_TYPED_ARRAY_RETVAL(env, cur_value, nullptr);
 
-    // TODO - consider stashing pointer buffers here...
-    nstatus = napi_get_typedarray_info(
-        env, cur_value, &array_type, &array_length, nullptr, nullptr, nullptr);
-    ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
-
-    // Get byte length?
-  }
-
-  TF_AutoStatus tf_status;
-  TF_AutoTensor tensor(
-      TF_AllocateTensor(TF_STRING, shape, shape_length, data_size));
-
-  return nullptr;
-}
-
-// Creates a TFE_TensorHandle from a JS array of string values.
-TFE_TensorHandle *CreateTFE_TensorHandleFromStringArray(
-    napi_env env, int64_t *shape, uint32_t shape_length, TF_DataType dtype,
-    napi_value array_value) {
-  napi_status nstatus;
-  uint32_t array_length;
-  nstatus = napi_get_array_length(env, array_value, &array_length);
-  ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
-
-  size_t offsets_size = array_length * sizeof(uint64_t);
-  size_t data_size = offsets_size;
-  size_t max_string_length = 0;
-  for (uint32_t i = 0; i < array_length; ++i) {
-    napi_value cur_value;
-    nstatus = napi_get_element(env, array_value, i, &cur_value);
-    ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
-    ENSURE_VALUE_IS_STRING_RETVAL(env, cur_value, nullptr);
-
-    size_t str_length;
+    // TODO(kreeger): Consider stashing pointer buffers here...
+    size_t cur_array_length;
+    napi_typedarray_type array_type;
     nstatus =
-        napi_get_value_string_utf8(env, cur_value, nullptr, 0, &str_length);
+        napi_get_typedarray_info(env, cur_value, &array_type, &cur_array_length,
+                                 nullptr, nullptr, nullptr);
     ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-    data_size += TF_StringEncodedSize(str_length);
-    max_string_length = std::max(max_string_length, str_length);
+    // Only Uint8 typed arrays are supported.
+    if (array_type != napi_uint8_array) {
+      NAPI_THROW_ERROR(env,
+                       "Unsupported array type - expecting Uint8 typed array");
+      return nullptr;
+    }
+
+    data_size += TF_StringEncodedSize(cur_array_length);
   }
 
   TF_AutoStatus tf_status;
@@ -250,43 +228,25 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromStringArray(
   void *tensor_data = TF_TensorData(tensor.tensor);
   uint64_t *offsets = (uint64_t *)tensor_data;
 
-  // Allocate some heap space to work with loading strings to encode with
-  // TensorFlow:
-  max_string_length++;
-  char *buffer = (char *)malloc(sizeof(char *) * max_string_length);
+  uint8_t *str_tensor_data_start =
+      static_cast<uint8_t *>(tensor_data) + offsets_size;
+  uint8_t *cur_tensor_data = str_tensor_data_start;
 
-  // Loop past offsets to ensure values fit.
-  char *str_data_start = (char *)tensor_data + offsets_size;
-  char *cur_str_data = str_data_start;
   for (uint32_t i = 0; i < array_length; ++i) {
     napi_value cur_value;
     nstatus = napi_get_element(env, array_value, i, &cur_value);
-    if (nstatus != napi_ok) {
-      free(buffer);
-      ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
-    }
+    ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+    ENSURE_VALUE_IS_TYPED_ARRAY_RETVAL(env, cur_value, nullptr);
 
-    // Read the current string into the char buffer:
-    size_t str_length;
-    nstatus = napi_get_value_string_utf8(env, cur_value, buffer,
-                                         max_string_length, &str_length);
-    if (nstatus != napi_ok) {
-      free(buffer);
-      ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
-    }
+    size_t cur_array_length;
+    nstatus = napi_get_typedarray_info(
+        env, cur_value, nullptr, &cur_array_length,
+        reinterpret_cast<void **>(&cur_tensor_data), nullptr, nullptr);
+    ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-    // Append the encoded string into the tensor data chunk:
-    size_t encoded_size = TF_StringEncode(buffer, str_length, cur_str_data,
-                                          data_size, tf_status.status);
-    if (TF_GetCode(tf_status.status) != TF_OK) {
-      free(buffer);
-      ENSURE_TF_OK_RETVAL(env, tf_status, nullptr);
-    }
-
-    offsets[i] = cur_str_data - str_data_start;
-    cur_str_data += encoded_size;
+    offsets[i] = cur_tensor_data - str_tensor_data_start;
+    cur_tensor_data += cur_array_length;
   }
-  free(buffer);
 
   TFE_TensorHandle *tfe_tensor_handle =
       TFE_NewTensorHandle(tensor.tensor, tf_status.status);
@@ -306,8 +266,8 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromJSValues(napi_env env,
     return CreateTFE_TensorHandleFromTypedArray(env, shape, shape_length, dtype,
                                                 array_value);
   } else {
-    return CreateTFE_TensorHandleFromStringUtf8StringArray(
-        env, shape, shape_length, dtype, array_value);
+    return CreateTFE_TensorHandleFromUtf8StringArray(env, shape, shape_length,
+                                                     dtype, array_value);
   }
 }
 
@@ -356,6 +316,8 @@ void CopyTFE_TensorHandleDataToTypedArray(napi_env env,
   // TFE_TensorHandleResolve can use a shared data pointer, memcpy() the
   // current value to the newly allocated NAPI buffer.
   memcpy(array_buffer_data, TF_TensorData(tensor.tensor), byte_length);
+
+  std::cerr << "hi\n";
 
   nstatus = napi_create_typedarray(env, array_type, num_elements,
                                    array_buffer_value, 0, result);
@@ -519,8 +481,11 @@ void CopyTFE_TensorHandleDataToJSData(napi_env env, TFE_Context *tfe_context,
   }
 
   if (is_string) {
-    CopyTFE_TensorHandleDataToStringArray(env, tfe_context, tfe_tensor_handle,
-                                          result);
+    /* CopyTFE_TensorHandleDataToStringArray(env, tfe_context, tfe_tensor_handle, */
+    /*                                       result); */
+    CopyTFE_TensorHandleDataToTypedArray(env, tfe_context, tfe_tensor_handle,
+                                         tensor_data_type, typed_array_type,
+                                         result);
   } else if (is_resource) {
     CopyTFE_TensorHandleDataToResourceArray(env, tfe_context, tfe_tensor_handle,
                                             result);

--- a/binding/tfjs_backend.cc
+++ b/binding/tfjs_backend.cc
@@ -182,6 +182,40 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromTypedArray(napi_env env,
   return tfe_tensor_handle;
 }
 
+// TODO(kreeger): Doc me
+TFE_TensorHandle *CreateTFE_TensorHandleFromStringUtf8StringArray(
+    napi_env env, int64_t *shape, uint32_t shape_length, TF_DataType dtype,
+    napi_value array_value) {
+  napi_status nstatus;
+
+  uint32_t array_length;
+  nstatus = napi_get_array_length(env, array_value, &array_length);
+  ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+
+  size_t offsets_size = array_length * sizeof(uint64_t);
+  size_t data_size = offsets_size;
+
+  for (uint32_t i = 0; i < array_length; ++i) {
+    napi_value cur_value;
+    nstatus = napi_get_element(env, array_value, i, &cur_value);
+    ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+    ENSURE_VALUE_IS_TYPED_ARRAY_RETVAL(env, cur_value, nullptr);
+
+    // TODO - consider stashing pointer buffers here...
+    nstatus = napi_get_typedarray_info(
+        env, cur_value, &array_type, &array_length, nullptr, nullptr, nullptr);
+    ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
+
+    // Get byte length?
+  }
+
+  TF_AutoStatus tf_status;
+  TF_AutoTensor tensor(
+      TF_AllocateTensor(TF_STRING, shape, shape_length, data_size));
+
+  return nullptr;
+}
+
 // Creates a TFE_TensorHandle from a JS array of string values.
 TFE_TensorHandle *CreateTFE_TensorHandleFromStringArray(
     napi_env env, int64_t *shape, uint32_t shape_length, TF_DataType dtype,
@@ -272,8 +306,8 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromJSValues(napi_env env,
     return CreateTFE_TensorHandleFromTypedArray(env, shape, shape_length, dtype,
                                                 array_value);
   } else {
-    return CreateTFE_TensorHandleFromStringArray(env, shape, shape_length,
-                                                 dtype, array_value);
+    return CreateTFE_TensorHandleFromStringUtf8StringArray(
+        env, shape, shape_length, dtype, array_value);
   }
 }
 

--- a/binding/tfjs_backend.cc
+++ b/binding/tfjs_backend.cc
@@ -22,8 +22,6 @@
 #include "tfe_auto_op.h"
 #include "utils.h"
 
-#include <iostream>
-
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -230,7 +228,6 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromUtf8StringArray(
   char *str_data_start = (char *)tensor_data + offsets_size;
   char *cur_str_data = str_data_start;
 
-  size_t idx = offsets_size;
   for (uint32_t i = 0; i < array_length; ++i) {
     napi_value cur_value;
     nstatus = napi_get_element(env, array_value, i, &cur_value);
@@ -239,17 +236,16 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromUtf8StringArray(
     size_t cur_array_length;
     void *buffer = nullptr;
     nstatus = napi_get_typedarray_info(
-        env, cur_value, nullptr, &cur_array_length,
-        &buffer, nullptr, nullptr);
+        env, cur_value, nullptr, &cur_array_length, &buffer, nullptr, nullptr);
     ENSURE_NAPI_OK_RETVAL(env, nstatus, nullptr);
 
-    size_t encoded_size = TF_StringEncode(
-        reinterpret_cast<char*>(buffer), cur_array_length, cur_str_data, data_size, tf_status.status);
+    size_t encoded_size =
+        TF_StringEncode(reinterpret_cast<char *>(buffer), cur_array_length,
+                        cur_str_data, data_size, tf_status.status);
     ENSURE_TF_OK_RETVAL(env, tf_status, nullptr);
 
     offsets[i] = cur_str_data - str_data_start;
     cur_str_data += encoded_size;
-    idx += encoded_size;
   }
 
   TFE_TensorHandle *tfe_tensor_handle =

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "yalc": "~1.0.0-pre.21"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "~1.2.2",
+    "@tensorflow/tfjs": "~1.2.3",
     "adm-zip": "^0.4.11",
     "https-proxy-agent": "^2.2.1",
     "node-pre-gyp": "0.13.0",

--- a/src/io/node_http_test.ts
+++ b/src/io/node_http_test.ts
@@ -52,7 +52,7 @@ const modelTopology1: {} = {
       'activation': 'linear',
       'trainable': true,
       'kernel_regularizer': null,
-      'bias_initializer': {'class_name': 'Zeros', 'config': {}},
+      'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
       'units': 1,
       'batch_input_shape': [null, 3],
       'use_bias': true,
@@ -65,7 +65,7 @@ const modelTopology1: {} = {
 describe('nodeHTTPRequest-load', () => {
   let requestInits: RequestInit[];
   const setupFakeWeightFiles = (fileBufferMap: {
-    [filename: string]: string|Float32Array|Int32Array|ArrayBuffer|Uint8Array|
+    [filename: string]: string | Float32Array | Int32Array | ArrayBuffer | Uint8Array |
     Uint16Array
   }) => {
     spyOn(tfc.util, 'fetch').and.callFake((path: string, init: RequestInit) => {
@@ -74,14 +74,14 @@ describe('nodeHTTPRequest-load', () => {
         if (path.endsWith('model.json')) {
           contentType = JSON_TYPE;
         } else if (
-            path.endsWith('weightfile0') || path.endsWith('weightfile1')) {
+          path.endsWith('weightfile0') || path.endsWith('weightfile1')) {
           contentType = OCTET_STREAM_TYPE;
         } else {
           reject(new Error(`Invalid path: ${path}`));
         }
         requestInits.push(init);
         resolve(new fetch.Response(
-            fileBufferMap[path], {'headers': {'Content-Type': contentType}}));
+          fileBufferMap[path], { 'headers': { 'Content-Type': contentType } }));
       });
     });
   };
@@ -116,22 +116,23 @@ describe('nodeHTTPRequest-load', () => {
     const floatData = new Float32Array([1, 3, 3, 7]);
     setupFakeWeightFiles({
       'http://localhost/model.json': JSON.stringify(
-          {modelTopology: modelTopology1, weightsManifest: weightManifest1}),
+        { modelTopology: modelTopology1, weightsManifest: weightManifest1 }),
       'http://localhost/weightfile0': floatData,
     });
 
     const handler = tfn.io.nodeHTTPRequest(
-        'http://localhost/model.json',
-        {credentials: 'include', cache: 'no-cache'});
+      'http://localhost/model.json',
+      { credentials: 'include', cache: 'no-cache' });
     const modelArtifacts = await handler.load();
     expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
     expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
     expect(new Float32Array(modelArtifacts.weightData)).toEqual(floatData);
 
     expect(requestInits).toEqual([
-      {credentials: 'include', cache: 'no-cache'}, {
+      { credentials: 'include', cache: 'no-cache' }, {
         credentials: 'include',
         cache: 'no-cache',
+        headers: { responseType: 'arraybuffer' }
       }
     ]);
   });
@@ -155,7 +156,7 @@ describe('nodeHTTPRequest-load', () => {
     const floatData = new Float32Array([1, 3, 3, 7]);
     setupFakeWeightFiles({
       'https://localhost/model.json': JSON.stringify(
-          {modelTopology: modelTopology1, weightsManifest: weightManifest1}),
+        { modelTopology: modelTopology1, weightsManifest: weightManifest1 }),
       'https://localhost/weightfile0': floatData,
     });
 

--- a/src/io/node_http_test.ts
+++ b/src/io/node_http_test.ts
@@ -52,7 +52,7 @@ const modelTopology1: {} = {
       'activation': 'linear',
       'trainable': true,
       'kernel_regularizer': null,
-      'bias_initializer': { 'class_name': 'Zeros', 'config': {} },
+      'bias_initializer': {'class_name': 'Zeros', 'config': {}},
       'units': 1,
       'batch_input_shape': [null, 3],
       'use_bias': true,
@@ -65,7 +65,7 @@ const modelTopology1: {} = {
 describe('nodeHTTPRequest-load', () => {
   let requestInits: RequestInit[];
   const setupFakeWeightFiles = (fileBufferMap: {
-    [filename: string]: string | Float32Array | Int32Array | ArrayBuffer | Uint8Array |
+    [filename: string]: string|Float32Array|Int32Array|ArrayBuffer|Uint8Array|
     Uint16Array
   }) => {
     spyOn(tfc.util, 'fetch').and.callFake((path: string, init: RequestInit) => {
@@ -74,14 +74,14 @@ describe('nodeHTTPRequest-load', () => {
         if (path.endsWith('model.json')) {
           contentType = JSON_TYPE;
         } else if (
-          path.endsWith('weightfile0') || path.endsWith('weightfile1')) {
+            path.endsWith('weightfile0') || path.endsWith('weightfile1')) {
           contentType = OCTET_STREAM_TYPE;
         } else {
           reject(new Error(`Invalid path: ${path}`));
         }
         requestInits.push(init);
         resolve(new fetch.Response(
-          fileBufferMap[path], { 'headers': { 'Content-Type': contentType } }));
+            fileBufferMap[path], {'headers': {'Content-Type': contentType}}));
       });
     });
   };
@@ -116,23 +116,23 @@ describe('nodeHTTPRequest-load', () => {
     const floatData = new Float32Array([1, 3, 3, 7]);
     setupFakeWeightFiles({
       'http://localhost/model.json': JSON.stringify(
-        { modelTopology: modelTopology1, weightsManifest: weightManifest1 }),
+          {modelTopology: modelTopology1, weightsManifest: weightManifest1}),
       'http://localhost/weightfile0': floatData,
     });
 
     const handler = tfn.io.nodeHTTPRequest(
-      'http://localhost/model.json',
-      { credentials: 'include', cache: 'no-cache' });
+        'http://localhost/model.json',
+        {credentials: 'include', cache: 'no-cache'});
     const modelArtifacts = await handler.load();
     expect(modelArtifacts.modelTopology).toEqual(modelTopology1);
     expect(modelArtifacts.weightSpecs).toEqual(weightManifest1[0].weights);
     expect(new Float32Array(modelArtifacts.weightData)).toEqual(floatData);
 
     expect(requestInits).toEqual([
-      { credentials: 'include', cache: 'no-cache' }, {
+      {credentials: 'include', cache: 'no-cache'}, {
         credentials: 'include',
         cache: 'no-cache',
-        headers: { responseType: 'arraybuffer' }
+        headers: {responseType: 'arraybuffer'}
       }
     ]);
   });
@@ -156,7 +156,7 @@ describe('nodeHTTPRequest-load', () => {
     const floatData = new Float32Array([1, 3, 3, 7]);
     setupFakeWeightFiles({
       'https://localhost/model.json': JSON.stringify(
-        { modelTopology: modelTopology1, weightsManifest: weightManifest1 }),
+          {modelTopology: modelTopology1, weightsManifest: weightManifest1}),
       'https://localhost/weightfile0': floatData,
     });
 

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -123,8 +123,6 @@ export class NodeJSKernelBackend extends KernelBackend {
         if (info.values != null) {
           // Values were delayed to write into the TensorHandle. Do that before
           // Op execution and clear stored values.
-          console.log('data: ');
-          console.log(info.values);
           info.id =
               this.binding.createTensor(info.shape, info.dtype, info.values);
           info.values = null;
@@ -228,11 +226,6 @@ export class NodeJSKernelBackend extends KernelBackend {
     const info = this.tensorMap.get(dataId);
     info.values = values;
     this.tensorMap.set(dataId, info);
-
-    // if (info.dtype === this.binding.TF_STRING) {
-    //   console.log('data: ');
-    //   console.log(info.values);
-    // }
   }
 
   register(dataId: object, shape: number[], dtype: DataType): void {

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -123,6 +123,8 @@ export class NodeJSKernelBackend extends KernelBackend {
         if (info.values != null) {
           // Values were delayed to write into the TensorHandle. Do that before
           // Op execution and clear stored values.
+          console.log('data: ');
+          console.log(info.values);
           info.id =
               this.binding.createTensor(info.shape, info.dtype, info.values);
           info.values = null;

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -21,7 +21,7 @@ import {EPSILON_FLOAT32} from '@tensorflow/tfjs-core/dist/backends/backend';
 import {Conv2DInfo, Conv3DInfo} from '@tensorflow/tfjs-core/dist/ops/conv_util';
 import {Activation} from '@tensorflow/tfjs-core/dist/ops/fused_util';
 import {Tensor5D} from '@tensorflow/tfjs-core/dist/tensor';
-import {upcastType} from '@tensorflow/tfjs-core/dist/types';
+import {BackendValues, upcastType} from '@tensorflow/tfjs-core/dist/types';
 import {isNullOrUndefined} from 'util';
 
 import {Int64Scalar} from './int64_tensors';
@@ -32,7 +32,7 @@ import {TensorMetadata, TFEOpAttr, TFJSBinding} from './tfjs_binding';
 type TensorInfo = {
   shape: number[],
   dtype: number,
-  values: Float32Array|Int32Array|Uint8Array,
+  values: BackendValues,
   id: number
 };
 
@@ -194,11 +194,11 @@ export class NodeJSKernelBackend extends KernelBackend {
 
   dispose(): void {}
 
-  async read(dataId: object): Promise<Float32Array|Int32Array|Uint8Array> {
+  async read(dataId: object): Promise<BackendValues> {
     return this.readSync(dataId);
   }
 
-  readSync(dataId: object): Float32Array|Int32Array|Uint8Array {
+  readSync(dataId: object): BackendValues {
     if (!this.tensorMap.has(dataId)) {
       throw new Error(`Tensor ${dataId} was not registered!`);
     }
@@ -218,7 +218,7 @@ export class NodeJSKernelBackend extends KernelBackend {
     this.tensorMap.delete(dataId);
   }
 
-  write(dataId: object, values: Float32Array|Int32Array|Uint8Array): void {
+  write(dataId: object, values: BackendValues): void {
     if (!this.tensorMap.has(dataId)) {
       throw new Error(`Tensor ${dataId} was not registered!`);
     }
@@ -226,6 +226,11 @@ export class NodeJSKernelBackend extends KernelBackend {
     const info = this.tensorMap.get(dataId);
     info.values = values;
     this.tensorMap.set(dataId, info);
+
+    // if (info.dtype === this.binding.TF_STRING) {
+    //   console.log('data: ');
+    //   console.log(info.values);
+    // }
   }
 
   register(dataId: object, shape: number[], dtype: DataType): void {

--- a/src/str_demo.ts
+++ b/src/str_demo.ts
@@ -1,6 +1,0 @@
-import * as tf from './index';
-
-const a = tf.tensor(['a', 'b']);
-const b = a.reshape([2, 1, 1]);
-console.log('a: ' + a.dataSync());
-console.log('b: ' + b.dataSync());

--- a/src/str_demo.ts
+++ b/src/str_demo.ts
@@ -1,0 +1,6 @@
+import * as tf from './index';
+
+const a = tf.tensor(['a', 'b']);
+const b = a.reshape([2, 1, 1]);
+console.log('a: ' + a.dataSync());
+console.log('b: ' + b.dataSync());

--- a/src/tfjs_binding.ts
+++ b/src/tfjs_binding.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {BackendValues} from '@tensorflow/tfjs-core/dist/types';
+
 export declare class TensorMetadata {
   id: number;
   shape: number[];
@@ -32,9 +34,7 @@ export interface TFJSBinding {
   TFEOpAttr: typeof TFEOpAttr;
 
   // Creates a tensor with the backend:
-  createTensor(
-      shape: number[], dtype: number,
-      buffer: Float32Array|Int32Array|Uint8Array): number;
+  createTensor(shape: number[], dtype: number, buffer: BackendValues): number;
 
   // Deletes a tensor with the backend:
   deleteTensor(tensorId: number): void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,15 +90,15 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@tensorflow/tfjs-converter@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.2.tgz#c95e2f79b1de830b8079c7704dc8463ced2d2b79"
-  integrity sha512-NM2NcPRHpCNeJdBxHcYpmW9ZHTQ2lJFJgmgGpQ8CxSC9CtQB05bFONs3SKcwMNDE/69QBRVom5DYqLCVUg+A+g==
+"@tensorflow/tfjs-converter@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.3.tgz#b56a0833326ac5f150a0a024a260a3911e77eed1"
+  integrity sha512-bCzkGvy6cpcl1LI8prKPz76+eRF/RjK3RLdMv5YW2LFCK2wXcaOtc5+EsKDGKJi+a3n+BeqeOFPc/QpYB/VRew==
 
-"@tensorflow/tfjs-core@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.2.tgz#2efa89e323612a26aeccee9b3ae9f5ac5a635bbe"
-  integrity sha512-2hCHMKjh3UNpLEjbAEaurrTGJyj/KpLtMSAraWgHA1vGY0kmk50BBSbgCDmXWUVm7lyh/SkCq4/GrGDZktEs3g==
+"@tensorflow/tfjs-core@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.3.tgz#90cc7bb593ba67548d683ff045823872a05c43dc"
+  integrity sha512-jLYUJYzI/b+058yKz9SjX6KwTac4hKFRh1FMI8jQpN289z9MSfKBq8BzpKd7n7ml7b55ae157Qta5pFmLwRVZw==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
@@ -106,31 +106,29 @@
     "@types/webgl2" "0.0.4"
     node-fetch "~2.1.2"
     seedrandom "2.4.3"
-  optionalDependencies:
-    rollup-plugin-visualizer "~1.1.1"
 
-"@tensorflow/tfjs-data@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.2.2.tgz#bd802b4096df04277d302d66598aef47fbffef85"
-  integrity sha512-oHGBoGdnCl2RyouLKplQqo+iil0iJgPbi/aoHizhpO77UBuJXlKMblH8w5GbxVAw3hKxWlqzYpxPo6rVRgehNA==
+"@tensorflow/tfjs-data@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.2.3.tgz#fb9c79c7bff03f95e7f174d755910ce06be17cf0"
+  integrity sha512-MOjsFAfiFPHGmq+WS1C3dQB2nEdeRvA0IAto/2atJUOlY41NLdGyhcnDZASLe/dPfGGARNXhOXtSSj7LY0yvIQ==
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
 
-"@tensorflow/tfjs-layers@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.2.2.tgz#3365dbbca7cfa4fcc6cacc9fffc90d664606bd4e"
-  integrity sha512-yzWZaZrCVpEyTkSrzMe4OOP4aGUfaaROE/zR9fPsPGGF8wLlbLNZUJjeYUmjy3G3pXGaM0mQUbLR5Vd707CVtQ==
+"@tensorflow/tfjs-layers@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.2.3.tgz#54811948c563ca8544884d0a85e06ec1c49018b0"
+  integrity sha512-qxvYbccObIXLy2c28RrOlZ+mYi7jtQrKGLB3LsOOOmEtWhuHv1d4FcSIimHy0KrnsbBxvy+v7lRG0Zvaqwn7iQ==
 
-"@tensorflow/tfjs@~1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.2.2.tgz#e0cc7f1c4139e7c38f3ea478999f0972d354c948"
-  integrity sha512-HfhSzL2eTWhlT0r/A5wmo+u3bHe+an16p5wsnFH3ujn21fQ8QtGpSfDHQZjWx1kVFaQnV6KBG+17MOrRHoHlLA==
+"@tensorflow/tfjs@~1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.2.3.tgz#7a806b36331325504020c66acddb38fb06d1e4a6"
+  integrity sha512-eJAAKU0Tcj84khnl3vjz1liACSsWUAegcWbsg+brG2uXOS96ayXWLGaxtjMtubpSxvaGKtJrqQTmXzRf4jaCaQ==
   dependencies:
-    "@tensorflow/tfjs-converter" "1.2.2"
-    "@tensorflow/tfjs-core" "1.2.2"
-    "@tensorflow/tfjs-data" "1.2.2"
-    "@tensorflow/tfjs-layers" "1.2.2"
+    "@tensorflow/tfjs-converter" "1.2.3"
+    "@tensorflow/tfjs-core" "1.2.3"
+    "@tensorflow/tfjs-data" "1.2.3"
+    "@tensorflow/tfjs-layers" "1.2.3"
 
 "@types/events@*":
   version "3.0.0"
@@ -799,11 +797,6 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1212,13 +1205,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-opn@^5.4.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
-  integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
-  dependencies:
-    is-wsl "^1.1.0"
-
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -1518,16 +1504,6 @@ rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-visualizer@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-1.1.1.tgz#454ae0aed23845407ebfb81cc52114af308d6d90"
-  integrity sha512-7xkSKp+dyJmSC7jg2LXqViaHuOnF1VvIFCnsZEKjrgT5ZVyiLLSbeszxFcQSfNJILphqgAEmWAUz0Z4xYScrRw==
-  dependencies:
-    mkdirp "^0.5.1"
-    opn "^5.4.0"
-    source-map "^0.7.3"
-    typeface-oswald "0.0.54"
-
 safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -1597,11 +1573,6 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spawn-wrap@^1.4.2:
   version "1.4.2"
@@ -1808,11 +1779,6 @@ tsutils@^2.12.1:
   integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   dependencies:
     tslib "^1.8.1"
-
-typeface-oswald@0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/typeface-oswald/-/typeface-oswald-0.0.54.tgz#1e253011622cdd50f580c04e7d625e7f449763d7"
-  integrity sha512-U1WMNp4qfy4/3khIfHMVAIKnNu941MXUfs3+H9R8PFgnoz42Hh9pboSFztWr86zut0eXC8byalmVhfkiKON/8Q==
 
 typescript@3.3.3333:
   version "3.3.3333"


### PR DESCRIPTION
This PR will re-work string usage in the tfjs-node C++ binding code. Currently, the binding reads out string values as string values (`char*`) and fits them into a heap-based buffer (avoid stack thrashing). 

With the change in tfjs-core, the buffers are already managed by V8 so need to manage a heap buffer. However, strings tensors must be encoded using the appropriate TF APIs. This change handles writing uint8 array buffers into TF Tensors, and re-rendering them into typed arrays before surfacing to JS land.

I don't think unit tests will pass here until tfjs-union is published.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/279)
<!-- Reviewable:end -->
