### PR TITLE
Build node native addon from source in CI tests

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -12,7 +12,7 @@ steps:
   entrypoint: 'yarn'
   id: 'test-ts-integration'
   args: ['test-ts-integration']
-  waitFor: ['yarn']
+  waitFor: ['yarn', 'test']
 timeout: 1800s
 logsBucket: 'gs://tfjs-build-logs'
 options:

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -9,6 +9,7 @@
 
 set -e
 
+yarn build-addon-from-source
 yarn build
 yarn lint
 yarn test

--- a/scripts/test-ts-integration.sh
+++ b/scripts/test-ts-integration.sh
@@ -21,7 +21,7 @@ function print_status() {
 }
 
 function test() {
-  yarn && yarn build && yarn yalc publish
+  yarn && yarn build-addon-from-source && yarn build && yarn yalc publish
 
   cd integration/typescript
   yarn && yarn yalc add '@tensorflow/tfjs-node' && yarn prep && yarn test


### PR DESCRIPTION
The CI tests runs against latest version which might include changes in `binding/*`. So it should build addon from source instead of downloading pre-compiled addon.

Make `test-ts-integration` wait for `test` to avoid race condition when compiling addon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/282)
<!-- Reviewable:end -->
