### PR TITLE
Update command to publish and link tfjs-node locally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,14 @@ $ yarn publish-local
 ```
 
 This command packs the `tfjs-node` package and publishes locally through [yalc](https://github.com/whitecolor/yalc).
-NOTE: Dependent packages must install this locally published package through yalc.
+NOTE: Dependent packages must install this locally published package through yalc and compile the node native addon locally:
+
+```sh
+$ yalc link @tensorflow/tfjs-node
+$ cd .yalc/@tensorflow/tfjs-node
+$ yarn && yarn build-addon-from-source
+$ cd ../../..
+```
 
 #### Run tests
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,7 @@ $ yarn publish-local
 ```
 
 This command packs the `tfjs-node` package and publishes locally through [yalc](https://github.com/whitecolor/yalc).
-NOTE: Dependent packages must install this locally published package through yalc and compile the node native addon locally:
+NOTE: Dependent packages must install this locally published package through yalc and compile the node native addon locally. In the dependent package run the following command to link local published `tfjs-node` package:
 
 ```sh
 $ yalc link @tensorflow/tfjs-node


### PR DESCRIPTION
To try tfjs-node locally with yalc, the TensorFlow C library and node native addon is not published by yalc. User need to go to the package in .yalc folder and compile node native addon from source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/288)
<!-- Reviewable:end -->
