### PR TITLE
Revert package_name in package.json after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "napi_versions": [
       3,
       4
-    ],
-    "package_name": "CPU-darwin-1.2.6.tar.gz"
+    ]
   }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -58,10 +58,25 @@ const platform = os.platform();
 let libType = process.argv[2] === undefined ? 'cpu' : process.argv[2];
 let forceDownload = process.argv[3] === undefined ? undefined : process.argv[3];
 
+let packageJsonFile;
+
+async function setPackageJsonFile() {
+  packageJsonFile = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
+}
+
 async function updateAddonName() {
-  const file = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`).toString());
-  file['binary']['package_name'] = addonName;
-  const stringFile = JSON.stringify(file, null, 2)
+  packageJsonFile['binary']['package_name'] = addonName;
+  const stringFile = JSON.stringify(packageJsonFile, null, 2);
+  fs.writeFile((`${__dirname}/../package.json`), stringFile, err => {
+    if (err) {
+      console.log('Faile to update addon name in package.json: ' + err);
+    }
+  });
+}
+
+async function revertAddonName() {
+  delete packageJsonFile['binary']['package_name'];
+  const stringFile = JSON.stringify(packageJsonFile, null, 2);
   fs.writeFile((`${__dirname}/../package.json`), stringFile, err => {
     if (err) {
       console.log('Faile to update addon name in package.json: ' + err);
@@ -189,6 +204,8 @@ async function build() {
  * Ensures libtensorflow requirements are met for building the binding.
  */
 async function run() {
+  // Load package.json file
+  setPackageJsonFile();
   // Update addon name in package.json file
   await updateAddonName();
   // First check if deps library exists:
@@ -200,6 +217,7 @@ async function run() {
     await cleanDeps();
     await downloadLibtensorflow(build);
   }
+  revertAddonName();
 }
 
 run();


### PR DESCRIPTION
The field `package_name` in package.json file is only used when downloading pre-compiled node addon. The value (such as CPU-darwin-1.2.5.tar.gz) is different for each platform, package version, and cpu/gpu. 

During development, the value might be change when developers switch platforms and the change is included in PR, which is confusing for reviewers. 

This PR will make the field `package_name` a temp field during installation and will be removed after installation. So the change will not be included in PRs.

Fix: https://github.com/tensorflow/tfjs/issues/1756

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/292)
<!-- Reviewable:end -->
