### PR TITLE
Adds encodeJpeg and encodePng

### DIFF
--- a/binding/tfjs_backend.cc
+++ b/binding/tfjs_backend.cc
@@ -87,7 +87,8 @@ TFE_TensorHandle *CreateTFE_TensorHandleFromTypedArray(napi_env env,
       width = sizeof(int32_t);
       break;
     case napi_uint8_array:
-      if (dtype != TF_BOOL) {
+      // TODO: why TF_BOOL?
+      if (dtype != TF_BOOL && dtype != TF_UINT8) {
         NAPI_THROW_ERROR(env, "Tensor type does not match Uint8Array");
         return nullptr;
       }

--- a/src/decode_image.ts
+++ b/src/decode_image.ts
@@ -18,7 +18,7 @@
 import {Tensor3D, Tensor4D, tidy, util} from '@tensorflow/tfjs-core';
 import {ensureTensorflowBackend, nodeBackend} from './ops/op_utils';
 
-enum ImageType {
+export enum ImageType {
   JPEG = 'jpeg',
   PNG = 'png',
   GIF = 'gif',
@@ -193,7 +193,7 @@ export function decodeImage(
 /**
  * Helper function to get image type based on starting bytes of the image file.
  */
-function getImageType(content: Uint8Array): string {
+export function getImageType(content: Uint8Array): string {
   // Classify the contents of a file based on starting bytes (aka magic number:
   // tslint:disable-next-line:max-line-length
   // https://en.wikipedia.org/wiki/Magic_number_(programming)#Magic_numbers_in_files)

--- a/src/decode_image_test.ts
+++ b/src/decode_image_test.ts
@@ -232,7 +232,7 @@ describe('decode images', () => {
   });
 });
 
-async function getUint8ArrayFromImage(path: string) {
+export async function getUint8ArrayFromImage(path: string) {
   const image = await readFile(path);
   const buf = Buffer.from(image);
   return new Uint8Array(buf);

--- a/src/encode_image.ts
+++ b/src/encode_image.ts
@@ -19,23 +19,23 @@ import {Tensor, Tensor3D, Rank} from '@tensorflow/tfjs-core';
 import {ensureTensorflowBackend, nodeBackend} from './ops/op_utils';
 
 export async function encodeJpeg(
-  image: Tensor3D, format: '' | 'grayscale' | 'rgb' = '', quality: number = 95,
-  progressive: boolean = false, optimize_size: boolean = false,
-  chroma_downsampling: boolean = true, density_unit: 'in' | 'cm' = 'in',
-  x_density: number = 300, y_density: number = 300, xmp_metadata: string = ''
+  image: Tensor3D, format: '' | 'grayscale' | 'rgb' = '', quality = 95,
+  progressive = false, optimizeSize = false,
+  chromaDownsampling = true, densityUnit: 'in' | 'cm' = 'in',
+  xDensity = 300, yDensity = 300, xmpMetadata = ''
   ): Promise<Uint8Array> {
   ensureTensorflowBackend();
 
   const backendEncodeImage = (imageData: Uint8Array) =>
     nodeBackend().encodeJpeg(
-      imageData, image.shape, format, quality, progressive, optimize_size,
-      chroma_downsampling, density_unit, x_density, y_density, xmp_metadata);
+      imageData, image.shape, format, quality, progressive, optimizeSize,
+      chromaDownsampling, densityUnit, xDensity, yDensity, xmpMetadata);
 
     return encodeImage(image, backendEncodeImage);
 }
 
 export async function encodePng(
-  image: Tensor3D, compression: number = 1
+  image: Tensor3D, compression = 1
   ): Promise<Uint8Array> {
   ensureTensorflowBackend();
 
@@ -51,6 +51,7 @@ async function encodeImage(
     await image.data()));
 
   const encodedPngData = (
+    // tslint:disable-next-line:no-any
     await encodedDataTensor.data())[0] as any as Uint8Array;
   encodedDataTensor.dispose();
   return encodedPngData;

--- a/src/encode_image.ts
+++ b/src/encode_image.ts
@@ -18,7 +18,22 @@
 import {Tensor3D} from '@tensorflow/tfjs-core';
 import {ensureTensorflowBackend, nodeBackend} from './ops/op_utils';
 
-export function encodeJpeg(image: Tensor3D): Uint8Array {
+export async function encodeJpeg(
+  image: Tensor3D, format: '' | 'grayscale' | 'rgb' = '', quality: number = 95,
+  progressive: boolean = false, optimize_size: boolean = false,
+  chroma_downsampling: boolean = true, density_unit: 'in' | 'cm' = 'in',
+  x_density: number = 300, y_density: number = 300, xmp_metadata: string = ''
+  ): Promise<Uint8Array> {
   ensureTensorflowBackend();
-  return nodeBackend().encodeJpeg(image);
+
+  const imageData = new Uint8Array(await image.data())
+  const encodedJpegTensor = nodeBackend().encodeJpeg(
+    imageData, image.shape, format, quality,
+    progressive, optimize_size, chroma_downsampling, density_unit, x_density,
+    y_density, xmp_metadata);
+
+  const encodedJpegData = (
+    await encodedJpegTensor.data())[0] as any as Uint8Array;
+  encodedJpegTensor.dispose();
+  return encodedJpegData;
 }

--- a/src/encode_image.ts
+++ b/src/encode_image.ts
@@ -18,7 +18,7 @@
 import {Tensor3D} from '@tensorflow/tfjs-core';
 import {ensureTensorflowBackend, nodeBackend} from './ops/op_utils';
 
-export function encodeJpeg(image: Tensor3D): string {
+export function encodeJpeg(image: Tensor3D): Uint8Array {
   ensureTensorflowBackend();
   return nodeBackend().encodeJpeg(image);
 }

--- a/src/encode_image.ts
+++ b/src/encode_image.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,23 +15,10 @@
  * =============================================================================
  */
 
-/**
- * Public API symbols under the tf.node.* namespace.
- */
+import {Tensor3D} from '@tensorflow/tfjs-core';
+import {ensureTensorflowBackend, nodeBackend} from './ops/op_utils';
 
-import {tensorBoard} from './callbacks';
-// tslint:disable-next-line:max-line-length
-import {decodeBmp, decodeGif, decodeImage, decodeJpeg, decodePng} from './decode_image';
-import {encodeJpeg} from './encode_image';
-import {summaryFileWriter} from './tensorboard';
-
-export const node = {
-  decodeImage,
-  decodeBmp,
-  decodeGif,
-  decodePng,
-  decodeJpeg,
-  encodeJpeg,
-  summaryFileWriter,
-  tensorBoard
-};
+export function encodeJpeg(image: Tensor3D): string {
+  ensureTensorflowBackend();
+  return nodeBackend().encodeJpeg(image);
+}

--- a/src/encode_image_test.ts
+++ b/src/encode_image_test.ts
@@ -14,22 +14,15 @@
  * limitations under the License.
  * =============================================================================
  */
+import * as tf from '.';
+import {getImageType, ImageType} from './decode_image';
 
-import {test_util} from '@tensorflow/tfjs-core';
-import * as tf from './index';
-import {getUint8ArrayFromImage} from './decode_image_test';
 
 fdescribe('encode images', () => {
   it('encodeJpeg', async () => {
-    const uint8array =
-        await getUint8ArrayFromImage('test_images/image_png_test.png');
-    const jpegTensor = tf.tensor3d(new Uint8Array([238, 101, 0, 50, 50, 50, 100, 50, 0, 200, 100, 50]), [2, 2, 3]);
-    const jpegString = await tf.node.encodeJpeg(jpegTensor);
-    jpegTensor.dispose();
-    console.log(jpegString)
-    // TODO
-    test_util.expectArraysEqual(
-        new Uint8Array(Buffer.from(jpegString).buffer),
-        uint8array);
+    const imageTensor = tf.tensor3d(new Uint8Array([239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
+    const jpegEncodedData = await tf.node.encodeJpeg(imageTensor);
+    imageTensor.dispose();
+    expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
   });
 });

--- a/src/encode_image_test.ts
+++ b/src/encode_image_test.ts
@@ -20,14 +20,62 @@ import {getImageType, ImageType} from './decode_image';
 
 fdescribe('encode images', () => {
   it('encodeJpeg', async () => {
-    const imageTensor = tf.tensor3d(new Uint8Array([239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
+    const imageTensor = tf.tensor3d(new Uint8Array(
+      [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
     const jpegEncodedData = await tf.node.encodeJpeg(imageTensor);
     imageTensor.dispose();
     expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
   });
+
+  it('encodeJpeg grayscale', async () => {
+    const imageTensor = tf.tensor3d(new Uint8Array(
+      [239, 0, 47, 0]), [2, 2, 1]);
+    const jpegEncodedData = await tf.node.encodeJpeg(imageTensor, 'grayscale');
+    imageTensor.dispose();
+    expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
+  });
+
+  it('encodeJpeg with parameters', async () => {
+    const imageTensor = tf.tensor3d(new Uint8Array(
+      [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
+    const format = 'rgb';
+    const quality = 50;
+    const progressive = true;
+    const optimize_size = true;
+    const chroma_downsampling = false;
+    const density_unit = 'cm';
+    const x_density = 500;
+    const y_density = 500;
+
+    const jpegEncodedData = await tf.node.encodeJpeg(imageTensor, format,
+      quality, progressive, optimize_size, chroma_downsampling, density_unit,
+      x_density, y_density);
+    imageTensor.dispose();
+    expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
+  });
+
   it('encodePng', async () => {
-    const imageTensor = tf.tensor3d(new Uint8Array([239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
+    const imageTensor = tf.tensor3d(new Uint8Array(
+      [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
     const pngEncodedData = await tf.node.encodePng(imageTensor);
+    imageTensor.dispose();
+    expect(getImageType(pngEncodedData)).toEqual(ImageType.PNG);
+  });
+
+  it('encodePng grayscale', async () => {
+    const imageTensor = tf.tensor3d(new Uint8Array(
+      [239, 0, 47, 0]), [2, 2, 1]);
+    const pngEncodedData = await tf.node.encodePng(imageTensor);
+    imageTensor.dispose();
+    expect(getImageType(pngEncodedData)).toEqual(ImageType.PNG);
+  });
+
+  it('encodePng with parameters', async () => {
+    const imageTensor = tf.tensor3d(new Uint8Array(
+      [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
+    const compression = 4;
+
+    const pngEncodedData = await tf.node.encodePng(imageTensor, compression);
     imageTensor.dispose();
     expect(getImageType(pngEncodedData)).toEqual(ImageType.PNG);
   });

--- a/src/encode_image_test.ts
+++ b/src/encode_image_test.ts
@@ -18,7 +18,7 @@ import * as tf from '.';
 import {getImageType, ImageType} from './decode_image';
 
 
-fdescribe('encode images', () => {
+describe('encode images', () => {
   it('encodeJpeg', async () => {
     const imageTensor = tf.tensor3d(new Uint8Array(
       [239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);

--- a/src/encode_image_test.ts
+++ b/src/encode_image_test.ts
@@ -17,7 +17,6 @@
 import * as tf from '.';
 import {getImageType, ImageType} from './decode_image';
 
-
 describe('encode images', () => {
   it('encodeJpeg', async () => {
     const imageTensor = tf.tensor3d(new Uint8Array(
@@ -41,15 +40,15 @@ describe('encode images', () => {
     const format = 'rgb';
     const quality = 50;
     const progressive = true;
-    const optimize_size = true;
-    const chroma_downsampling = false;
-    const density_unit = 'cm';
-    const x_density = 500;
-    const y_density = 500;
+    const optimizeSize = true;
+    const chromaDownsampling = false;
+    const densityUnit = 'cm';
+    const xDensity = 500;
+    const yDensity = 500;
 
     const jpegEncodedData = await tf.node.encodeJpeg(imageTensor, format,
-      quality, progressive, optimize_size, chroma_downsampling, density_unit,
-      x_density, y_density);
+      quality, progressive, optimizeSize, chromaDownsampling, densityUnit,
+      xDensity, yDensity);
     imageTensor.dispose();
     expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
   });

--- a/src/encode_image_test.ts
+++ b/src/encode_image_test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {test_util} from '@tensorflow/tfjs-core';
+import * as tf from './index';
+import {getUint8ArrayFromImage} from './decode_image_test';
+
+fdescribe('encode images', () => {
+  it('encodeJpeg', async () => {
+    const uint8array =
+        await getUint8ArrayFromImage('test_images/image_png_test.png');
+    const jpegTensor = tf.tensor3d(new Uint8Array([238, 101, 0, 50, 50, 50, 100, 50, 0, 200, 100, 50]), [2, 2, 3]);
+    const jpegString = await tf.node.encodeJpeg(jpegTensor);
+    jpegTensor.dispose();
+    console.log(jpegString)
+    // TODO
+    test_util.expectArraysEqual(
+        new Uint8Array(Buffer.from(jpegString).buffer),
+        uint8array);
+  });
+});

--- a/src/encode_image_test.ts
+++ b/src/encode_image_test.ts
@@ -25,4 +25,10 @@ fdescribe('encode images', () => {
     imageTensor.dispose();
     expect(getImageType(jpegEncodedData)).toEqual(ImageType.JPEG);
   });
+  it('encodePng', async () => {
+    const imageTensor = tf.tensor3d(new Uint8Array([239, 100, 0, 46, 48, 47, 92, 49, 0, 194, 98, 47]), [2, 2, 3]);
+    const pngEncodedData = await tf.node.encodePng(imageTensor);
+    imageTensor.dispose();
+    expect(getImageType(pngEncodedData)).toEqual(ImageType.PNG);
+  });
 });

--- a/src/node.ts
+++ b/src/node.ts
@@ -22,7 +22,7 @@
 import {tensorBoard} from './callbacks';
 // tslint:disable-next-line:max-line-length
 import {decodeBmp, decodeGif, decodeImage, decodeJpeg, decodePng} from './decode_image';
-import {encodeJpeg} from './encode_image';
+import {encodeJpeg, encodePng} from './encode_image';
 import {summaryFileWriter} from './tensorboard';
 
 export const node = {
@@ -32,6 +32,7 @@ export const node = {
   decodePng,
   decodeJpeg,
   encodeJpeg,
+  encodePng,
   summaryFileWriter,
   tensorBoard
 };

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -1673,6 +1673,31 @@ export class NodeJSKernelBackend extends KernelBackend {
         Tensor<Rank.R4>;
   }
 
+  encodeJpeg(
+      image: Tensor3D, format: '' | 'grayscale' | 'rgb' = '', quality: number = 95,
+      progressive: boolean = false, optimize_size: boolean = false,
+      chroma_downsampling: boolean = true, density_unit: 'in' | 'cm' = 'in',
+      x_density: number = 300, y_density: number = 300, xmp_metadata: string = ''
+      ): string {
+    const opAttrs = [
+      {name: 'format', type: this.binding.TF_ATTR_STRING, value: format},
+      {name: 'quality', type: this.binding.TF_ATTR_INT, value: quality},
+      {name: 'progressive', type: this.binding.TF_ATTR_BOOL, value: progressive},
+      {name: 'optimize_size', type: this.binding.TF_ATTR_BOOL, value: optimize_size},
+      {name: 'chroma_downsampling', type: this.binding.TF_ATTR_BOOL, value: chroma_downsampling},
+      {name: 'density_unit', type: this.binding.TF_ATTR_STRING, value: density_unit},
+      {name: 'x_density', type: this.binding.TF_ATTR_INT, value: x_density},
+      {name: 'y_density', type: this.binding.TF_ATTR_INT, value: y_density},
+      {name: 'xmp_metadata', type: this.binding.TF_ATTR_STRING, value: xmp_metadata}
+    ];
+
+    // TODO: how to create a uint8 tensor?
+    const inputTensorId = this.binding.createTensor(image.shape, this.binding.TF_UINT8, new Uint8Array(image.dataSync()));
+    const outputMetadata = this.binding.executeOp(
+      'EncodeJpeg', opAttrs, [inputTensorId], 1);
+    return this.createOutputTensor(outputMetadata[0]).dataSync()[0] as any as string;
+  }
+
   // ------------------------------------------------------------
   // TensorBoard-related (tfjs-node-specific) backend kernels.
 

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -1680,19 +1680,19 @@ export class NodeJSKernelBackend extends KernelBackend {
       imageShape, this.binding.TF_UINT8, imageData);
     const outputMetadata = this.binding.executeOp(
       name, opAttrs, [inputTensorId], 1);
-    const outputTensorInfo = outputMetadata[0]
+    const outputTensorInfo = outputMetadata[0];
     // prevent the tensor data from being converted to a UTF8 string, since
     // the encoded data is not valid UTF8
-    outputTensorInfo.dtype = this.binding.TF_UINT8
+    outputTensorInfo.dtype = this.binding.TF_UINT8;
     return this.createOutputTensor(outputTensorInfo);
   }
 
   encodeJpeg(
       imageData: Uint8Array, imageShape: number[],
       format: '' | 'grayscale' | 'rgb', quality: number, progressive: boolean,
-      optimize_size: boolean, chroma_downsampling: boolean,
-      density_unit: 'in' | 'cm', x_density: number, y_density: number,
-      xmp_metadata: string
+      optimizeSize: boolean, chromaDownsampling: boolean,
+      densityUnit: 'in' | 'cm', xDensity: number, yDensity: number,
+      xmpMetadata: string
       ): Tensor<Rank> {
     const opAttrs = [
       {name: 'format', type: this.binding.TF_ATTR_STRING, value: format},
@@ -1705,24 +1705,24 @@ export class NodeJSKernelBackend extends KernelBackend {
       {
         name: 'optimize_size',
         type: this.binding.TF_ATTR_BOOL,
-        value: optimize_size
+        value: optimizeSize
       },
       {
         name: 'chroma_downsampling',
         type: this.binding.TF_ATTR_BOOL,
-        value: chroma_downsampling
+        value: chromaDownsampling
       },
       {
         name: 'density_unit',
         type: this.binding.TF_ATTR_STRING,
-        value: density_unit
+        value: densityUnit
       },
-      {name: 'x_density', type: this.binding.TF_ATTR_INT, value: x_density},
-      {name: 'y_density', type: this.binding.TF_ATTR_INT, value: y_density},
+      {name: 'x_density', type: this.binding.TF_ATTR_INT, value: xDensity},
+      {name: 'y_density', type: this.binding.TF_ATTR_INT, value: yDensity},
       {
         name: 'xmp_metadata',
         type: this.binding.TF_ATTR_STRING,
-        value: xmp_metadata
+        value: xmpMetadata
       }
     ];
     return this.executeEncodeImageOp(

--- a/src/nodejs_kernel_backend.ts
+++ b/src/nodejs_kernel_backend.ts
@@ -1674,11 +1674,11 @@ export class NodeJSKernelBackend extends KernelBackend {
   }
 
   encodeJpeg(
-      image: Tensor3D, format: '' | 'grayscale' | 'rgb' = '', quality: number = 95,
+      imageData: Uint8Array, imageShape: number[], format: '' | 'grayscale' | 'rgb' = '', quality: number = 95,
       progressive: boolean = false, optimize_size: boolean = false,
       chroma_downsampling: boolean = true, density_unit: 'in' | 'cm' = 'in',
       x_density: number = 300, y_density: number = 300, xmp_metadata: string = ''
-      ): Uint8Array {
+      ): Tensor<Rank> {
     const opAttrs = [
       {name: 'format', type: this.binding.TF_ATTR_STRING, value: format},
       {name: 'quality', type: this.binding.TF_ATTR_INT, value: quality},
@@ -1692,14 +1692,14 @@ export class NodeJSKernelBackend extends KernelBackend {
     ];
 
     // TODO: how to create a uint8 tensor?
-    const inputTensorId = this.binding.createTensor(image.shape, this.binding.TF_UINT8, new Uint8Array(image.dataSync()));
+    const inputTensorId = this.binding.createTensor(imageShape, this.binding.TF_UINT8, imageData);
     const outputMetadata = this.binding.executeOp('EncodeJpeg', opAttrs, [inputTensorId], 1);
 
     const outputTensorInfo = outputMetadata[0]
     // prevent the tensor data from being converted to a UTF8 string, since
     // the encoded data is not valid UTF8
     outputTensorInfo.dtype = this.binding.TF_UINT8
-    return this.createOutputTensor(outputTensorInfo).dataSync()[0] as any as Uint8Array;
+    return this.createOutputTensor(outputTensorInfo);
   }
 
   // ------------------------------------------------------------


### PR DESCRIPTION
This PR exposes the bindings to tf.io.encode_jpeg and tf.image.encode_png. 

The image decoding operations have been added to tfjs-node a while ago, but currently we still need the node canvas package to save images. That's why I suggest to include these bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-node/296)
<!-- Reviewable:end -->
